### PR TITLE
infiot: support for not not installing routes to the kernel

### DIFF
--- a/lib/command.c
+++ b/lib/command.c
@@ -146,6 +146,7 @@ const char *node_names[] = {
 				     */
 	"bfd",			 /* BFD_NODE */
 	"bfd peer",		 /* BFD_PEER_NODE */
+	"kernel-route"  /*KERNEL_ROUTE_NODE */
 };
 /* clang-format on */
 

--- a/lib/command.h
+++ b/lib/command.h
@@ -141,6 +141,7 @@ enum node_type {
 	BGP_FLOWSPECV6_NODE,	/* BGP IPv6 FLOWSPEC Address-Family */
 	BFD_NODE,		 /* BFD protocol mode. */
 	BFD_PEER_NODE,		 /* BFD peer configuration mode. */
+	KERNEL_ROUTE_NODE, /* Kernel Routing Attributes */
 	NODE_TYPE_MAX, /* maximum */
 };
 

--- a/vtysh/vtysh_config.c
+++ b/vtysh/vtysh_config.c
@@ -301,6 +301,8 @@ void vtysh_config_parse_line(void *arg, const char *line)
 			config = config_get(VRF_DEBUG_NODE, line);
 		else if (strncmp(line, "debug", strlen("debug")) == 0)
 			config = config_get(DEBUG_NODE, line);
+		else if (strncmp(line, "kernel-route", strlen("kernel-route")) == 0)
+			config = config_get(KERNEL_ROUTE_NODE, line);
 		else if (strncmp(line, "password", strlen("password")) == 0
 			 || strncmp(line, "enable password",
 				    strlen("enable password"))
@@ -344,7 +346,7 @@ void vtysh_config_parse_line(void *arg, const char *line)
 	 || (I) == ACCESS_IPV6_NODE || (I) == ACCESS_MAC_NODE                  \
 	 || (I) == PREFIX_IPV6_NODE || (I) == FORWARDING_NODE                  \
 	 || (I) == DEBUG_NODE || (I) == AAA_NODE || (I) == VRF_DEBUG_NODE      \
-	 || (I) == MPLS_NODE)
+	 || (I) == MPLS_NODE) || (I) == KERNEL_ROUTE_NODE
 
 /* Display configuration to file pointer. */
 void vtysh_config_dump(void)

--- a/zebra/rt_netlink.h
+++ b/zebra/rt_netlink.h
@@ -71,6 +71,8 @@ extern int netlink_neigh_read(struct zebra_ns *zns);
 extern int netlink_neigh_read_for_vlan(struct zebra_ns *zns,
 				       struct interface *vlan_if);
 
+extern void rt_netlink_set_skip_install(uint8_t setflag);
+
 #endif /* HAVE_NETLINK */
 
 #endif /* _ZEBRA_RT_NETLINK_H */


### PR DESCRIPTION
* add support via CLI to not install routes to the kernel via RTNETLINK
  but continue to send routes to another dataplane via FPM
  CLI: run in configure terminal mode
  [no] kernel-route skip-install