### PR TITLE
infiot: improve debugging and fix overlay subnet match

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -7893,6 +7893,8 @@ void route_vty_out_detail(struct vty *vty, struct bgp *bgp, struct prefix *p,
 				vty_out(vty, ", best");
 		}
 
+		vty_out(vty, ", type %d", binfo->type);
+
 		if (json_bestpath)
 			json_object_object_add(json_path, "bestpath",
 					       json_bestpath);

--- a/zebra/zebra_rnh.c
+++ b/zebra/zebra_rnh.c
@@ -536,7 +536,16 @@ static int check_overlay_nexthop(struct prefix *pp, uint8_t *isreachable)
 
 	*isreachable = 1;
 
+	inet_ntop(g_infovlay_prefix.family, &g_infovlay_prefix.u.prefix, via, PREFIX2STR_BUFFER);
+	zlog_debug("Overlay Prefix %s", via); 
+
 	if (prefix_match(&g_infovlay_prefix, pp) == 0) {
+		*isreachable = 0;
+		if (IS_ZEBRA_DEBUG_NHT) {
+			inet_ntop(pp->family, &pp->u.prefix, via, PREFIX2STR_BUFFER);
+			snprintf(cntrname, 256, "overlay.%s", via);
+			zlog_debug("Infiot via: %s, val %d", via, 0); 
+		}
 		return *isreachable;
 	}
 
@@ -630,7 +639,11 @@ zebra_rnh_resolve_nexthop_entry(vrf_id_t vrfid, int family,
 
 			hook_call(evaluate_custom_nexthop, &nrn->p, &isreachable);
 			if (isreachable == 0) {
-				return NULL;	
+				continue;	
+			}
+
+			if (isreachable) {
+				break;
 			}
 #endif
 			//if (!check_overlay(NULL, &nrn->p)) {


### PR DESCRIPTION
* print the route type in the detailed route output
  `sh ip bgp X.X.X.X/Y`
* fix the overlay subnet parsing that was broken
* continue nh resolution after failure to find a better nh match