### PR TITLE
infiot: add debugs in zebra_fpm to print bytes_written

### DIFF
--- a/zebra/zebra_fpm.c
+++ b/zebra/zebra_fpm.c
@@ -1002,6 +1002,8 @@ static int zfpm_write_cb(struct thread *thread)
 			write(zfpm_g->sock, stream_pnt(s), bytes_to_write);
 		zfpm_g->stats.write_calls++;
 		num_writes++;
+		zfpm_debug("sent out fd:%d bytes_to_write:%ld bytes_written:%ld",
+				zfpm_g->sock, bytes_to_write, bytes_written);
 
 		if (bytes_written < 0) {
 			if (ERRNO_IO_RETRY(errno))


### PR DESCRIPTION
Adding debug when socket sends out to print bytes_written.
This should help match with FRRFpm::selected read buf_len