### PR TITLE
infiot: changing debug from zfpm_debug to zlog_debug in zebra_fpm

### DIFF
--- a/zebra/zebra_fpm.c
+++ b/zebra/zebra_fpm.c
@@ -1002,7 +1002,7 @@ static int zfpm_write_cb(struct thread *thread)
 			write(zfpm_g->sock, stream_pnt(s), bytes_to_write);
 		zfpm_g->stats.write_calls++;
 		num_writes++;
-		zfpm_debug("sent out fd:%d bytes_to_write:%ld bytes_written:%ld",
+		zlog_debug("sent out fd:%d bytes_to_write:%ld bytes_written:%ld",
 				zfpm_g->sock, bytes_to_write, bytes_written);
 
 		if (bytes_written < 0) {

--- a/zebra/zebra_rnh.c
+++ b/zebra/zebra_rnh.c
@@ -541,7 +541,9 @@ static int check_overlay_nexthop(struct prefix *pp, uint8_t *isreachable)
 	*isreachable = 1;
 
 	inet_ntop(g_infovlay_prefix.family, &g_infovlay_prefix.u.prefix, via, PREFIX2STR_BUFFER);
-	zlog_debug("Overlay Prefix %s", via); 
+	if (IS_ZEBRA_DEBUG_NHT) {
+		zlog_debug("Overlay Prefix %s", via);
+	}
 
 	if (prefix_match(&g_infovlay_prefix, pp) == 0) {
 		*isreachable = 1;


### PR DESCRIPTION
The last debug added required enabling debug zebra fpm to get
the logs.
Also, suppressing the Overlay Prefix log as too many gets printed
in the scale setups.