### PR TITLE
infiot: fix nhtracking and overlay subnet match

### DIFF
--- a/bgpd/bgp_nht.c
+++ b/bgpd/bgp_nht.c
@@ -591,9 +591,10 @@ static void sendmsg_zebra_rnh(struct bgp_nexthop_cache *bnc, int command)
 	ret = zclient_send_rnh(zclient, command, p, exact_match,
 			       bnc->bgp->vrf_id);
 	/* TBD: handle the failure */
-	if (ret < 0)
+	if (ret < 0){
 		zlog_warn("sendmsg_nexthop: zclient_send_message() failed");
-
+		return;
+	}
 	if ((command == ZEBRA_NEXTHOP_REGISTER)
 	    || (command == ZEBRA_IMPORT_ROUTE_REGISTER))
 		SET_FLAG(bnc->flags, BGP_NEXTHOP_REGISTERED);

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -2536,7 +2536,9 @@ void bgp_zebra_init(struct thread_master *master, unsigned short instance)
 
 	/* Set default values. */
 	zclient = zclient_new_notify(master, &zclient_options_default);
-	zclient_init(zclient, ZEBRA_ROUTE_BGP, 0, &bgpd_privs);
+	//zclient_init(zclient, ZEBRA_ROUTE_BGP, 0, &bgpd_privs);
+
+	zclient_init_sync(zclient, ZEBRA_ROUTE_BGP, 0, &bgpd_privs);
 	zclient->zebra_connected = bgp_zebra_connected;
 	zclient->router_id_update = bgp_router_id_update;
 	zclient->interface_add = bgp_interface_add;

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -7815,6 +7815,7 @@ void bgp_init(unsigned short instance)
 	/* Init zebra. */
 	bgp_zebra_init(bm->master, instance);
 
+
 #if ENABLE_BGP_VNC
 	vnc_zebra_init(bm->master);
 #endif

--- a/lib/zclient.h
+++ b/lib/zclient.h
@@ -442,6 +442,8 @@ extern struct zclient *zclient_new_notify(struct thread_master *m,
 
 extern void zclient_init(struct zclient *, int, unsigned short,
 			 struct zebra_privs_t *privs);
+extern void zclient_init_sync(struct zclient *, int, unsigned short,
+			 struct zebra_privs_t *privs);			 
 extern int zclient_start(struct zclient *);
 extern void zclient_stop(struct zclient *);
 extern void zclient_reset(struct zclient *);

--- a/zebra/main.c
+++ b/zebra/main.c
@@ -209,6 +209,7 @@ struct quagga_signal_t zebra_signals[] = {
 
 void infnh_init(void);
 struct prefix g_infovlay_prefix;
+struct in_addr g_infovlay_ipv4;
 struct trkr_client *g_infovlay_trkr;
 uint8_t g_infovlay_cfgread = 0;
 #define ZEBRA_INFIOT_CUSTOM_NEXTHOP_CFGPATH "/infgw/inf_config.json"
@@ -282,14 +283,21 @@ static int infnh_readcfg()
 		goto error;
 	}
 	const char *ovlay_netmask_str = json_object_get_string(json_ovlay_netmask);
-	
-	struct in_addr nm, ipv4;
+
+	json_object_object_get_ex(dcfg_overlay, "ovlay_netmask_extended", &json_ovlay_netmask);
+
+	if (json_ovlay_netmask != NULL) {
+		ovlay_netmask_str = json_object_get_string(json_ovlay_netmask);
+	}
+
+	struct in_addr nm;
 	inet_pton(AF_INET, ovlay_netmask_str, &nm);
-	inet_pton(AF_INET, ovlay_ipv4_str, &ipv4);
-	g_infovlay_prefix.u.prefix4.s_addr = (ipv4.s_addr & nm.s_addr);
+	inet_pton(AF_INET, ovlay_ipv4_str, &g_infovlay_ipv4);
+	g_infovlay_prefix.u.prefix4.s_addr = (g_infovlay_ipv4.s_addr & nm.s_addr);
 
 	g_infovlay_prefix.family = AF_INET;
 	g_infovlay_prefix.prefixlen = ip_masklen(nm);
+
 	char bufn[INET6_ADDRSTRLEN];
 	prefix2str(&g_infovlay_prefix, bufn, INET6_ADDRSTRLEN);
 	//inet_pton(AF_INET, ovlay_ipv4_str, &g_infovlay_prefix.u.prefix4);


### PR DESCRIPTION
* parse overlay extended mask value and update the
infiot overlay prefix.

*currently reachability check is done based on overlay
subnet which causes all prefixes to be installed. updated
to check the reachability based on nh value from trkr.

*skip overlay subnet prefix match