### PR TITLE
ref #12108 retry in bgp socket connect

### DIFF
--- a/bgpd/bgp_nht.c
+++ b/bgpd/bgp_nht.c
@@ -591,9 +591,10 @@ static void sendmsg_zebra_rnh(struct bgp_nexthop_cache *bnc, int command)
 	ret = zclient_send_rnh(zclient, command, p, exact_match,
 			       bnc->bgp->vrf_id);
 	/* TBD: handle the failure */
-	if (ret < 0)
+	if (ret < 0){
 		zlog_warn("sendmsg_nexthop: zclient_send_message() failed");
-
+		return;
+	}
 	if ((command == ZEBRA_NEXTHOP_REGISTER)
 	    || (command == ZEBRA_IMPORT_ROUTE_REGISTER))
 		SET_FLAG(bnc->flags, BGP_NEXTHOP_REGISTERED);

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -2536,7 +2536,9 @@ void bgp_zebra_init(struct thread_master *master, unsigned short instance)
 
 	/* Set default values. */
 	zclient = zclient_new_notify(master, &zclient_options_default);
-	zclient_init(zclient, ZEBRA_ROUTE_BGP, 0, &bgpd_privs);
+	//zclient_init(zclient, ZEBRA_ROUTE_BGP, 0, &bgpd_privs);
+
+	zclient_init_sync(zclient, ZEBRA_ROUTE_BGP, 0, &bgpd_privs);
 	zclient->zebra_connected = bgp_zebra_connected;
 	zclient->router_id_update = bgp_router_id_update;
 	zclient->interface_add = bgp_interface_add;

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -7815,6 +7815,7 @@ void bgp_init(unsigned short instance)
 	/* Init zebra. */
 	bgp_zebra_init(bm->master, instance);
 
+
 #if ENABLE_BGP_VNC
 	vnc_zebra_init(bm->master);
 #endif

--- a/lib/zclient.h
+++ b/lib/zclient.h
@@ -442,6 +442,8 @@ extern struct zclient *zclient_new_notify(struct thread_master *m,
 
 extern void zclient_init(struct zclient *, int, unsigned short,
 			 struct zebra_privs_t *privs);
+extern void zclient_init_sync(struct zclient *, int, unsigned short,
+			 struct zebra_privs_t *privs);			 
 extern int zclient_start(struct zclient *);
 extern void zclient_stop(struct zclient *);
 extern void zclient_reset(struct zclient *);


### PR DESCRIPTION
*currently bgp schedules an event to zebra socket connect.
if bgp config is processed before the socket establishment,
then all the neighbor registeration will stall in bgp, as bgp
doesn't handle the rnh register failure with zebra.

*Added the zebra socket retry in bgp to retry for 12 times
with 10 seconds interval.

*This issue observed in a cluster where the storage is being
put in a cross regional account. it could cause the issue
as we aread the inf_config.json file in the zebra bootup.

*adding the patch to dev folder for future reference.