### PR TITLE
Fix for 12965 

### DIFF
--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -2538,7 +2538,6 @@ void bgp_zebra_init(struct thread_master *master, unsigned short instance)
 	zclient = zclient_new_notify(master, &zclient_options_default);
 	//zclient_init(zclient, ZEBRA_ROUTE_BGP, 0, &bgpd_privs);
 
-	zclient_init_sync(zclient, ZEBRA_ROUTE_BGP, 0, &bgpd_privs);
 	zclient->zebra_connected = bgp_zebra_connected;
 	zclient->router_id_update = bgp_router_id_update;
 	zclient->interface_add = bgp_interface_add;
@@ -2572,6 +2571,7 @@ void bgp_zebra_init(struct thread_master *master, unsigned short instance)
 	zclient->ipset_entry_notify_owner = ipset_entry_notify_owner;
 	zclient->iptable_notify_owner = iptable_notify_owner;
 	zclient->instance = instance;
+	zclient_init_sync(zclient, ZEBRA_ROUTE_BGP, 0, &bgpd_privs);
 }
 
 void bgp_zebra_destroy(void)


### PR DESCRIPTION
BGPd does not honor NHT reachability status sent by Zebra if zclient_num_connects is not set and does not mark routes invalid. zclient_num_connects was not set because we do zclient_connect_sync from bgpd before registering zclient callbacks. Fixed by moving zclient_connect_sync after registering zclient callbacks