### PR TITLE
BWAN-886 - Sending ebgp info as client info from bgp client

### DIFF
--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -702,7 +702,7 @@ void zclient_init_sync(struct zclient *zclient, int redist_default,
 
 
 int zclient_send_rnh(struct zclient *zclient, int command, struct prefix *p,
-		     bool exact_match, vrf_id_t vrf_id)
+		     bool exact_match, vrf_id_t vrf_id, uint8_t client_info)
 {
 	struct stream *s;
 
@@ -713,6 +713,7 @@ int zclient_send_rnh(struct zclient *zclient, int command, struct prefix *p,
 
 	stream_putw(s, PREFIX_FAMILY(p));
 	stream_putc(s, p->prefixlen);
+	stream_putc(s, client_info);
 	switch (PREFIX_FAMILY(p)) {
 	case AF_INET:
 		stream_put_in_addr(s, &p->u.prefix4);

--- a/lib/zclient.h
+++ b/lib/zclient.h
@@ -58,6 +58,9 @@
 #define ZEBRA_IPTABLES_FORWARD 0
 #define ZEBRA_IPTABLES_DROP    1
 
+#define ZEBRA_INF_BGP_NHT_IBGP_REG 1
+#define ZEBRA_INF_BGP_NHT_EBGP_REG 2
+
 extern struct sockaddr_storage zclient_addr;
 extern socklen_t zclient_addr_len;
 
@@ -597,7 +600,7 @@ extern void zebra_read_pw_status_update(int command, struct zclient *zclient,
 extern int zclient_route_send(uint8_t, struct zclient *, struct zapi_route *);
 extern int zclient_send_rnh(struct zclient *zclient, int command,
 			    struct prefix *p, bool exact_match,
-			    vrf_id_t vrf_id);
+			    vrf_id_t vrf_id, uint8_t clientinfo);
 extern int zapi_route_encode(uint8_t, struct stream *, struct zapi_route *);
 extern int zapi_route_decode(struct stream *, struct zapi_route *);
 bool zapi_route_notify_decode(struct stream *s, struct prefix *p,

--- a/pbrd/pbr_zebra.c
+++ b/pbrd/pbr_zebra.c
@@ -434,7 +434,7 @@ void pbr_send_rnh(struct nexthop *nhop, bool reg)
 	}
 
 	if (zclient_send_rnh(zclient, command, &p,
-			     false, nhop->vrf_id) < 0) {
+			     false, nhop->vrf_id, 0) < 0) {
 		zlog_warn("%s: Failure to send nexthop to zebra",
 			  __PRETTY_FUNCTION__);
 	}

--- a/pimd/pim_nht.c
+++ b/pimd/pim_nht.c
@@ -51,7 +51,7 @@ void pim_sendmsg_zebra_rnh(struct pim_instance *pim, struct zclient *zclient,
 	int ret;
 
 	p = &(pnc->rpf.rpf_addr);
-	ret = zclient_send_rnh(zclient, command, p, false, pim->vrf_id);
+	ret = zclient_send_rnh(zclient, command, p, false, pim->vrf_id, 0);
 	if (ret < 0)
 		zlog_warn("sendmsg_nexthop: zclient_send_message() failed");
 

--- a/sharpd/sharp_zebra.c
+++ b/sharpd/sharp_zebra.c
@@ -223,7 +223,7 @@ void sharp_zebra_nexthop_watch(struct prefix *p, bool watch)
 	if (!watch)
 		command = ZEBRA_NEXTHOP_UNREGISTER;
 
-	zclient_send_rnh(zclient, command, p, true, VRF_DEFAULT);
+	zclient_send_rnh(zclient, command, p, true, VRF_DEFAULT, 0);
 }
 
 static int sharp_nexthop_update(int command, struct zclient *zclient,

--- a/staticd/static_zebra.c
+++ b/staticd/static_zebra.c
@@ -335,7 +335,7 @@ void static_zebra_nht_register(struct static_route *si, bool reg)
 		static_nht_hash_free(nhtd);
 	}
 
-	if (zclient_send_rnh(zclient, cmd, &p, false, si->nh_vrf_id) < 0)
+	if (zclient_send_rnh(zclient, cmd, &p, false, si->nh_vrf_id, 0) < 0)
 		zlog_warn("%s: Failure to send nexthop to zebra",
 			  __PRETTY_FUNCTION__);
 }

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -1023,6 +1023,7 @@ static void zread_rnh_register(ZAPI_HANDLER_ARGS)
 	uint8_t flags = 0;
 	uint16_t type = cmd2type[hdr->command];
 	bool exist;
+        uint8_t client_info = 0;
 
 	if (IS_ZEBRA_DEBUG_NHT)
 		zlog_debug(
@@ -1039,7 +1040,8 @@ static void zread_rnh_register(ZAPI_HANDLER_ARGS)
 		STREAM_GETC(s, flags);
 		STREAM_GETW(s, p.family);
 		STREAM_GETC(s, p.prefixlen);
-		l += 4;
+		STREAM_GETC(s, client_info);
+		l += 5;
 		if (p.family == AF_INET) {
 			if (p.prefixlen > IPV4_MAX_BITLEN) {
 				zlog_warn(
@@ -1085,6 +1087,14 @@ static void zread_rnh_register(ZAPI_HANDLER_ARGS)
 					       ZEBRA_NHT_EXACT_MATCH))
 				UNSET_FLAG(rnh->flags, ZEBRA_NHT_EXACT_MATCH);
 		}
+ 
+                switch (client_info) {
+                   case ZEBRA_INF_BGP_NHT_EBGP_REG:
+                      SET_FLAG(rnh->client_info_flag , ZEBRA_NHT_EBGP);
+                   break;
+                   default:
+                      rnh->client_info_flag = 0;
+                }
 
 		zebra_add_rnh_client(rnh, client, type, zvrf_id(zvrf));
 		/* Anything not AF_INET/INET6 has been filtered out above */

--- a/zebra/zebra_rnh.c
+++ b/zebra/zebra_rnh.c
@@ -692,13 +692,19 @@ zebra_rnh_resolve_nexthop_entry(vrf_id_t vrfid, int family,
 					"re_type=%d rnh_flags=%d",
 					vrfid, bufn, re, rn, re->status, re->flags, re->type, rnh->flags);
 			}
-			hook_call(evaluate_custom_nexthop, &nrn->p, &isreachable);
-			if (isreachable) {
-				break;
-			}else if (prefix_match(&g_infovlay_prefix, &rn->p)){
-				zlog_debug("overlay supernet prefix node, so look for next re entry");
-				continue;
-			}
+			if (!CHECK_FLAG(rnh->client_info_flag , ZEBRA_NHT_EBGP)) {
+				hook_call(evaluate_custom_nexthop, &nrn->p, &isreachable);
+				if (isreachable) {
+					break;
+				}else if (prefix_match(&g_infovlay_prefix, &rn->p)){
+					zlog_debug("overlay supernet prefix node, so look for next re entry");
+					continue;
+				}
+			} else {
+			        if (IS_ZEBRA_DEBUG_NHT){
+				    zlog_debug("skipping custom nexthop check for prefix-%s", bufn);
+                                }
+                        }
 #endif
 			//if (!check_overlay(NULL, &nrn->p)) {
 			//	return NULL;

--- a/zebra/zebra_rnh.h
+++ b/zebra/zebra_rnh.h
@@ -33,6 +33,8 @@ struct rnh {
 #define ZEBRA_NHT_DELETED       0x2
 #define ZEBRA_NHT_EXACT_MATCH   0x4
 
+	uint8_t client_info_flag;
+#define ZEBRA_NHT_EBGP          0x1
 	/* VRF identifier. */
 	vrf_id_t vrf_id;
 


### PR DESCRIPTION
Issue - the custom overlay nexthop check gets hit for ebgp neighbor because it is in overlay subnet range due to which nexthop was unreachable

Fix - sending if nexthop is EBGP as client information during NHT registration by BGP client to Zebra

(cherry picked from commit 0c665e1ff856cd6afc852c35eeec9532619484f1)