### PR TITLE
vpn route leak does not happen for VRF BGP static route

### DIFF
--- a/bgpd/bgp_mplsvpn.c
+++ b/bgpd/bgp_mplsvpn.c
@@ -560,6 +560,9 @@ leak_update(
 		/* No nexthop tracking for redistributed routes */
 		if (bi_ultimate->sub_type == BGP_ROUTE_REDISTRIBUTE)
 			nh_valid = 1;
+                else if (bi_ultimate->sub_type == BGP_ROUTE_STATIC) {
+                        nh_valid = 1;
+                }
 		else
 			/*
 			 * TBD do we need to do anything about the
@@ -623,6 +626,9 @@ leak_update(
 	 */
 	if (bi_ultimate->sub_type == BGP_ROUTE_REDISTRIBUTE)
 		nh_valid = 1;
+        else if (bi_ultimate->sub_type == BGP_ROUTE_STATIC) {
+                nh_valid = 1;
+        }
 	else
 		/*
 		 * TBD do we need to do anything about the


### PR DESCRIPTION
VPN route are not exported as routes added as static bgp using network route CLI fails nexthop validation.
Skipping NH validity for leaked bgp static routes