### PR TITLE
BWAN-2913: Force installing the static routes during rib process.

### DIFF
--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -1490,7 +1490,7 @@ static void rib_process_update_fib(struct zebra_vrf *zvrf,
 					in_fib = true;
 					break;
 				}
-			if (!in_fib)
+			if (!in_fib || new->type == ZEBRA_ROUTE_STATIC)
 				rib_install_kernel(rn, new, NULL);
 		}
 	}


### PR DESCRIPTION
During rib process, Force installing the static routes during rib process even there is no change ideified in frr.

Fixes: https://netskope.atlassian.net/browse/BWAN-2913

Unit testing:
The fix verified in both of the following cases.
Case1: Static route not deleted after click restart.
Case2: Static route deleted after click restart but not installing in kernel.
Full test log attached on Jira.

```
>> enp2s0 - LAN, enp2s1 - WAN
>> Static Route 10.10.20.0/24 on enp2s0(LAN)
>> Static Route 10.10.30.0/24 on enp2s1(WAN)

#] ip -br a
lo               UNKNOWN        127.0.0.1/8 ::1/128
dummy0           UNKNOWN        fe80::72:5dff:fe0c:46d1/64
sit0@NONE        UNKNOWN        ::127.0.0.1/96
enp2s0           UP             10.10.10.10/24 fe80::20c:29ff:feee:d35b/64
enp2s1           UP             10.0.1.10/24 fe80::20c:29ff:feee:d365/64
enp2s2           UP             fe80::20c:29ff:feee:d36f/64
enp2s3           UP             fe80::20c:29ff:feee:d379/64
enp2s5           UP             192.168.168.2/24 fe80::20c:29ff:feee:d383/64
docker0          DOWN           172.17.0.1/16
overlay          UP             169.254.0.9/16 fe80::c5a7:2288:703a:a855/64

#] ip r s
default via 10.0.1.11 dev enp2s1 proto static metric 100
10.0.1.0/24 dev enp2s1 proto kernel scope link src 10.0.1.10
10.10.10.0/24 dev enp2s0 proto kernel scope link src 10.10.10.10
10.10.20.0/24 via 10.10.10.20 dev enp2s0 proto 196 metric 20
10.10.30.0/24 via 10.0.1.30 dev enp2s1 proto 196 metric 20
169.254.0.0/16 dev overlay proto kernel scope link src 169.254.0.9
169.254.0.1 dev overlay scope link
169.254.0.2 dev overlay scope link
169.254.0.3 dev overlay scope link
169.254.0.10 dev overlay scope link
172.17.0.0/16 dev docker0 proto kernel scope link src 172.17.0.1 linkdown
192.168.168.0/24 dev enp2s5 proto kernel scope link src 192.168.168.2

#] supervisorctl restart click
click: stopped
click: started

#] ip -br a
lo               UNKNOWN        127.0.0.1/8 ::1/128
dummy0           UNKNOWN        fe80::72:5dff:fe0c:46d1/64
sit0@NONE        UNKNOWN        ::127.0.0.1/96
enp2s0           UP             10.10.10.10/24 fe80::20c:29ff:feee:d35b/64
enp2s1           UP             10.0.1.10/24 fe80::20c:29ff:feee:d365/64
enp2s2           UP             fe80::20c:29ff:feee:d36f/64
enp2s3           UP             fe80::20c:29ff:feee:d379/64
enp2s5           UP             192.168.168.2/24 fe80::20c:29ff:feee:d383/64
docker0          DOWN           172.17.0.1/16

#] ip r s
default via 10.0.1.11 dev enp2s1 proto static metric 100
10.0.1.0/24 dev enp2s1 proto kernel scope link src 10.0.1.10
10.10.10.0/24 dev enp2s0 proto kernel scope link src 10.10.10.10
10.10.20.0/24 via 10.10.10.20 dev enp2s0 proto 196 metric 20
10.10.30.0/24 via 10.0.1.30 dev enp2s1 proto 196 metric 20
172.17.0.0/16 dev docker0 proto kernel scope link src 172.17.0.1 linkdown
192.168.168.0/24 dev enp2s5 proto kernel scope link src 192.168.168.2

>> Both the static routes installed
# ip r s
default via 10.0.1.11 dev enp2s1 proto static metric 100
10.0.1.0/24 dev enp2s1 proto kernel scope link src 10.0.1.10
10.10.10.0/24 dev enp2s0 proto kernel scope link src 10.10.10.10
10.10.20.0/24 via 10.10.10.20 dev enp2s0 proto 196 metric 20
10.10.30.0/24 via 10.0.1.30 dev enp2s1 proto 196 metric 20
169.254.0.0/16 dev overlay proto kernel scope link src 169.254.0.9
169.254.0.1 dev overlay scope link
169.254.0.2 dev overlay scope link
169.254.0.3 dev overlay scope link
169.254.0.10 dev overlay scope link
172.17.0.0/16 dev docker0 proto kernel scope link src 172.17.0.1 linkdown
192.168.168.0/24 dev enp2s5 proto kernel scope link src 192.168.168.2
root@SpokeNew:/infgw#
```