### PR TITLE
BWAN-2913: Force installing the static routes, fix porting.

### DIFF
--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -1490,7 +1490,7 @@ static void rib_process_update_fib(struct zebra_vrf *zvrf,
 					in_fib = true;
 					break;
 				}
-			if (!in_fib)
+			if (!in_fib || new->type == ZEBRA_ROUTE_STATIC)
 				rib_install_kernel(rn, new, NULL);
 		}
 	}


### PR DESCRIPTION
During rib process, Force installing the static routes during rib process even there is no change ideified in frr.

Fix ported from [infiot-frr-6.0.3-post-donatello](https://github.com/infiotinc/frr/tree/infiot-frr-6.0.3-post-donatello)

Fixes: https://netskope.atlassian.net/browse/BWAN-2913

Fix verified on Elsa, no explicit testing performed with this branch.