### PR TITLE
Draft Initial changes for BWAN-2309 overlay suboptimal routing

### DIFF
--- a/bgpd/bgp_nexthop.h
+++ b/bgpd/bgp_nexthop.h
@@ -40,6 +40,7 @@
 struct bgp_nexthop_cache {
 	/* IGP route's metric. */
 	uint32_t metric;
+        uint32_t overlay_path_cost;
 
 	/* Nexthop number and nexthop linked list.*/
 	uint8_t nexthop_num;

--- a/bgpd/bgp_nht.c
+++ b/bgpd/bgp_nht.c
@@ -389,9 +389,9 @@ void bgp_parse_nexthop_update(int command, vrf_id_t vrf_id)
 		char buf[PREFIX2STR_BUFFER];
 		prefix2str(&nhr.prefix, buf, sizeof(buf));
 		zlog_debug(
-			"%u: Rcvd NH update %s - metric %d/%d #nhops %d/%d flags 0x%x",
+			"%u: Rcvd NH update %s - metric %d/%d #nhops %d/%d flags 0x%x, overlay_cost %d/%d",
 			vrf_id, buf, nhr.metric, bnc->metric, nhr.nexthop_num,
-			bnc->nexthop_num, bnc->flags);
+			bnc->nexthop_num, bnc->flags, nhr.overlay_path_cost, bnc->overlay_path_cost);
 	}
 
 	if (nhr.metric != bnc->metric)
@@ -408,6 +408,7 @@ void bgp_parse_nexthop_update(int command, vrf_id_t vrf_id)
 		bnc->flags |= BGP_NEXTHOP_VALID;
 		bnc->metric = nhr.metric;
 		bnc->nexthop_num = nhr.nexthop_num;
+                bnc->overlay_path_cost = nhr.overlay_path_cost;
 
 		bnc->flags &= ~BGP_NEXTHOP_LABELED_VALID; /* check below */
 
@@ -460,6 +461,7 @@ void bgp_parse_nexthop_update(int command, vrf_id_t vrf_id)
 	} else {
 		bnc->flags &= ~BGP_NEXTHOP_VALID;
 		bnc->nexthop_num = nhr.nexthop_num;
+                bnc->overlay_path_cost = nhr.overlay_path_cost;
 
 		/* notify bgp fsm if nbr ip goes from valid->invalid */
 		UNSET_FLAG(bnc->flags, BGP_NEXTHOP_PEER_NOTIFIED);

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -87,6 +87,8 @@
 extern const char *bgp_origin_str[];
 extern const char *bgp_origin_long_str[];
 
+int g_enable_overlay_metric_pref = 0;
+
 /* PMSI strings. */
 #define PMSI_TNLTYPE_STR_NO_INFO "No info"
 #define PMSI_TNLTYPE_STR_DEFAULT PMSI_TNLTYPE_STR_NO_INFO
@@ -1855,7 +1857,7 @@ void bgp_best_selection(struct bgp *bgp, struct bgp_node *rn,
 
 	debug = bgp_debug_bestpath(&rn->p);
 
-	if (debug)
+        if (debug)
 		prefix2str(&rn->p, pfx_buf, sizeof(pfx_buf));
 
 	/* bgp deterministic-med */
@@ -1979,6 +1981,11 @@ void bgp_best_selection(struct bgp *bgp, struct bgp_node *rn,
 				 debug, pfx_buf, afi, safi)) {
 			new_select = ri;
 		}
+                if (g_enable_overlay_metric_pref && ri->nexthop->overlay_path_cost &&  new_select->nexthop->overlay_path_cost) {
+                	if (ri->nexthop->overlay_path_cost < new_select->nexthop->overlay_path_cost) {
+                		new_select = ri;
+                	}
+                }
 	}
 
 	/* Now that we know which path is the bestpath see if any of the other

--- a/lib/zclient.c
+++ b/lib/zclient.c
@@ -1271,6 +1271,7 @@ bool zapi_nexthop_update_decode(struct stream *s, struct zapi_route *nhr)
 	STREAM_GETW(s, nhr->instance);
 	STREAM_GETC(s, nhr->distance);
 	STREAM_GETL(s, nhr->metric);
+	STREAM_GETL(s, nhr->overlay_path_cost);
 	STREAM_GETC(s, nhr->nexthop_num);
 
 	for (i = 0; i < nhr->nexthop_num; i++) {

--- a/lib/zclient.h
+++ b/lib/zclient.h
@@ -345,6 +345,7 @@ struct zapi_route {
 	uint8_t distance;
 
 	uint32_t metric;
+        uint32_t overlay_path_cost;
 
 	route_tag_t tag;
 

--- a/zebra/zebra_rnh.h
+++ b/zebra/zebra_rnh.h
@@ -51,6 +51,7 @@ struct rnh {
 	 * if this has been filtered for the client
 	 */
 	int filtered[ZEBRA_ROUTE_MAX];
+        uint32_t overlay_path_cost;
 };
 
 typedef enum { RNH_NEXTHOP_TYPE, RNH_IMPORT_CHECK_TYPE } rnh_type_t;


### PR DESCRIPTION
Need click side changes to generate overlay metric considering end to end path reachability
Currently metric is inferred from overlay and nh counters which works to prefer optimal hub. For spoke to spoke cases we need click side changes to generate the overlay metric.
Code is disabled as of now with a flag