### PR TITLE
BWAN-9819: CLI to configure tcp timeout per neighbor

### DIFF
--- a/bgpd/bgp_fsm.c
+++ b/bgpd/bgp_fsm.c
@@ -1303,6 +1303,20 @@ static int bgp_connect_success(struct peer *peer)
 		return -1;
 	}
 
+	int val = atomic_load(&peer->tcpusrto);
+
+        if (CHECK_FLAG(peer->flags, PEER_FLAG_TCP_USER_TIMEOUT) &&
+            atomic_load(&peer->tcpusrto) > 0) {
+                if (setsockopt(peer->fd, IPPROTO_TCP, TCP_USER_TIMEOUT,
+                               &val, sizeof(val)) < 0) {
+                        zlog_warn("Failed to set TCP_USER_TIMEOUT for peer %s: %s",
+                                  peer->host, safe_strerror(errno));
+                } else {
+                        zlog_debug("TCP_USER_TIMEOUT set for peer %s to %d ms",
+                                   peer->host, val);
+                }
+        }
+
 	bgp_reads_on(peer);
 
 	if (bgp_debug_neighbor_events(peer)) {

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -5094,6 +5094,71 @@ DEFUN (no_neighbor_timers,
 	return peer_timers_unset_vty(vty, argv[idx_peer]->arg);
 }
 
+static int peer_tcp_user_timeout_set_vty(struct vty *vty, const char *ip_str,
+                                         const char *timeout_str)
+{
+    struct peer *peer;
+    uint32_t timeout_sec;
+    uint32_t timeout_ms;
+    int ret;
+
+    peer = peer_and_group_lookup_vty(vty, ip_str);
+    if (!peer) {
+        return CMD_WARNING_CONFIG_FAILED;
+    }
+
+    timeout_sec = strtoul(timeout_str, NULL, 10);
+    if (timeout_sec > 65535) {
+        vty_out(vty, "%% Invalid timeout value. Must be 0-65535 seconds.\n");
+        return CMD_WARNING_CONFIG_FAILED;
+    }
+
+    timeout_ms = timeout_sec * 1000;
+
+
+    ret = peer_tcp_user_timeout_set(peer, timeout_ms);
+    return bgp_vty_return(vty, ret);
+}
+
+static int peer_tcp_user_timeout_unset_vty(struct vty *vty, const char *ip_str)
+{
+    struct peer *peer;
+    int ret;
+
+    peer = peer_and_group_lookup_vty(vty, ip_str);
+    if (!peer)
+        return CMD_WARNING_CONFIG_FAILED;
+
+
+    ret = peer_tcp_user_timeout_unset(peer);
+    return bgp_vty_return(vty, ret);
+}
+
+DEFUN (neighbor_tcp_user_timeout,
+       neighbor_tcp_user_timeout_cmd,
+       "neighbor <A.B.C.D|X:X::X:X|WORD> tcp-user-timeout (0-65535)",
+       NEIGHBOR_STR
+       NEIGHBOR_ADDR_STR2
+       "Set TCP user timeout (in seconds)\n"
+       "TCP user timeout value\n")
+{
+    int idx_peer = 1;
+    int idx_val = 3;
+    return peer_tcp_user_timeout_set_vty(vty, argv[idx_peer]->arg,
+                                         argv[idx_val]->arg);
+}
+
+DEFUN (no_neighbor_tcp_user_timeout,
+       no_neighbor_tcp_user_timeout_cmd,
+       "no neighbor <A.B.C.D|X:X::X:X|WORD> tcp-user-timeout",
+       NO_STR
+       NEIGHBOR_STR
+       NEIGHBOR_ADDR_STR2
+       "Unset TCP user timeout")
+{
+    int idx_peer = 2;
+    return peer_tcp_user_timeout_unset_vty(vty, argv[idx_peer]->arg);
+}
 
 static int peer_timers_connect_set_vty(struct vty *vty, const char *ip_str,
 				       const char *time_str)
@@ -13302,6 +13367,8 @@ void bgp_vty_init(void)
 	/* "neighbor timers" commands. */
 	install_element(BGP_NODE, &neighbor_timers_cmd);
 	install_element(BGP_NODE, &no_neighbor_timers_cmd);
+	install_element(BGP_NODE, &neighbor_tcp_user_timeout_cmd);
+	install_element(BGP_NODE, &no_neighbor_tcp_user_timeout_cmd);
 
 	/* "neighbor timers connect" commands. */
 	install_element(BGP_NODE, &neighbor_timers_connect_cmd);

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -1206,6 +1206,7 @@ void peer_xfer_config(struct peer *peer_dst, struct peer *peer_src)
 	peer_dst->v_keepalive = peer_src->v_keepalive;
 	peer_dst->routeadv = peer_src->routeadv;
 	peer_dst->v_routeadv = peer_src->v_routeadv;
+        peer_dst->tcpusrto = peer_src->tcpusrto;
 
 	/* password apply */
 	if (peer_src->password && !peer_dst->password)
@@ -4827,6 +4828,49 @@ int peer_timers_unset(struct peer *peer)
 	return 0;
 }
 
+int peer_tcp_user_timeout_set(struct peer *peer, uint32_t timeout_ms)
+{
+    struct peer *member;
+    struct listnode *node, *nnode;
+
+    if (timeout_ms > (65535 * 1000))
+        return BGP_ERR_INVALID_VALUE;
+
+    SET_FLAG(peer->flags, PEER_FLAG_TCP_USER_TIMEOUT);
+    atomic_store(&peer->tcpusrto, timeout_ms);
+
+    if (!CHECK_FLAG(peer->sflags, PEER_STATUS_GROUP))
+        return 0;
+
+    for (ALL_LIST_ELEMENTS(peer->group->peer, node, nnode, member)) {
+
+        SET_FLAG(member->flags, PEER_FLAG_TCP_USER_TIMEOUT);
+        PEER_ATTR_INHERIT(member, peer->group, tcpusrto);
+    }
+
+    return 0;
+}
+
+int peer_tcp_user_timeout_unset(struct peer *peer)
+{
+    struct peer *member;
+    struct listnode *node, *nnode;
+
+    UNSET_FLAG(peer->flags, PEER_FLAG_TCP_USER_TIMEOUT);
+    atomic_store(&peer->tcpusrto, 0);
+
+    if (!CHECK_FLAG(peer->sflags, PEER_STATUS_GROUP))
+        return 0;
+
+    for (ALL_LIST_ELEMENTS(peer->group->peer, node, nnode, member)) {
+
+        UNSET_FLAG(member->flags, PEER_FLAG_TCP_USER_TIMEOUT);
+        atomic_store(&member->tcpusrto, 0);
+    }
+
+    return 0;
+}
+
 int peer_timers_connect_set(struct peer *peer, uint32_t connect)
 {
 	struct peer *member;
@@ -6943,6 +6987,9 @@ static void bgp_config_write_peer_global(struct vty *vty, struct bgp *bgp,
 		vty_out(vty, " neighbor %s timers %u %u\n", addr,
 			peer->keepalive, peer->holdtime);
 
+	if (peergroup_flag_check(peer, PEER_FLAG_TCP_USER_TIMEOUT))
+		vty_out(vty, " neighbor %s tcp-user-timeout %u \n", addr,
+			peer->tcpusrto);
 	/* timers connect */
 	if (peergroup_flag_check(peer, PEER_FLAG_TIMER_CONNECT))
 		vty_out(vty, " neighbor %s timers connect %u\n", addr,

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -901,6 +901,7 @@ struct peer {
 #define PEER_FLAG_PASSWORD                  (1 << 20) /* password */
 #define PEER_FLAG_LOCAL_AS                  (1 << 21) /* local-as */
 #define PEER_FLAG_UPDATE_SOURCE             (1 << 22) /* update-source */
+#define PEER_FLAG_TCP_USER_TIMEOUT          (1 << 23) /* tcp user timeout */
 
 	/* outgoing message sent in CEASE_ADMIN_SHUTDOWN notify */
 	char *tx_shutdown_message;
@@ -979,6 +980,7 @@ struct peer {
 	_Atomic uint32_t keepalive;
 	_Atomic uint32_t connect;
 	_Atomic uint32_t routeadv;
+	_Atomic uint32_t tcpusrto;
 
 	/* Timer values. */
 	_Atomic uint32_t v_start;
@@ -1624,6 +1626,8 @@ extern int peer_timers_set(struct peer *, uint32_t keepalive,
 			   uint32_t holdtime);
 extern int peer_timers_unset(struct peer *);
 
+extern int peer_tcp_user_timeout_set(struct peer *peer, uint32_t timeout_ms);
+extern int peer_tcp_user_timeout_unset(struct peer *peer);
 extern int peer_timers_connect_set(struct peer *, uint32_t);
 extern int peer_timers_connect_unset(struct peer *);
 


### PR DESCRIPTION
new CLI to configure TCP timeout per neighbor
CLI will be used in FRR configure automation in gw/controller