### PR TITLE
BWAN-11278: Forcing FIb install for static routes

### DIFF
--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -986,7 +986,7 @@ static int nexthop_active_update(struct route_node *rn, struct route_entry *re,
 			re->nexthop_active_num++;
 		/* Don't allow src setting on IPv6 addr for now */
 		if (prev_active != new_active || prev_index != nexthop->ifindex
-		    || ((nexthop->type >= NEXTHOP_TYPE_IFINDEX
+		    || (re->type == ZEBRA_ROUTE_STATIC) || ((nexthop->type >= NEXTHOP_TYPE_IFINDEX
 			 && nexthop->type < NEXTHOP_TYPE_IPV6)
 			&& prev_src.ipv4.s_addr
 				   != nexthop->rmap_src.ipv4.s_addr)


### PR DESCRIPTION
Currently there is no way to identify the recursive child resolved for static route nexthops as it is not stored as part of nexthop structure. Hence when there is any change in recursive resolution it is not pushed to FIB causing inconsistent static routes in FIB

Forcing route update to FIB for static routes to get away from this problem

(cherry picked from commit 7e3eb26b773eaf95e2d6cac1927ec150b108c6fa)