### PR TITLE
changing "bgp community/ext-community/as-path" commands to "ip community/ext-community/as-path" commands

### DIFF
--- a/bgpd/bgp_filter.c
+++ b/bgpd/bgp_filter.c
@@ -440,181 +440,7 @@ bool config_bgp_aspath_validate(const char *regstr)
 	return false;
 }
 
-DEFUN(as_path, bgp_as_path_cmd,
-      "bgp as-path access-list AS_PATH_FILTER_NAME [seq (0-4294967295)] <deny|permit> LINE...",
-      BGP_STR
-      "BGP autonomous system path filter\n"
-      "Specify an access list name\n"
-      "Regular expression access list name\n"
-      "Sequence number of an entry\n"
-      "Sequence number\n"
-      "Specify packets to reject\n"
-      "Specify packets to forward\n"
-      "A regular-expression (1234567890_^|[,{}() ]$*+.?-\\) to match the BGP AS paths\n")
-{
-	int idx = 0;
-	enum as_filter_type type;
-	struct as_filter *asfilter;
-	struct as_list *aslist;
-	regex_t *regex;
-	char *regstr;
-	int64_t seqnum = ASPATH_SEQ_NUMBER_AUTO;
-
-	/* Retrieve access list name */
-	argv_find(argv, argc, "AS_PATH_FILTER_NAME", &idx);
-	char *alname = argv[idx]->arg;
-
-	if (argv_find(argv, argc, "(0-4294967295)", &idx))
-		seqnum = (int64_t)atol(argv[idx]->arg);
-
-	/* Check the filter type. */
-	type = argv_find(argv, argc, "deny", &idx) ? AS_FILTER_DENY
-						   : AS_FILTER_PERMIT;
-
-	/* Check AS path regex. */
-	argv_find(argv, argc, "LINE", &idx);
-	regstr = argv_concat(argv, argc, idx);
-
-	regex = bgp_regcomp(regstr);
-	if (!regex) {
-		vty_out(vty, "can't compile regexp %s\n", regstr);
-		XFREE(MTYPE_TMP, regstr);
-		return CMD_WARNING_CONFIG_FAILED;
-	}
-
-	if (!config_bgp_aspath_validate(regstr)) {
-		vty_out(vty, "Invalid character in as-path access-list %s\n",
-			regstr);
-		XFREE(MTYPE_TMP, regstr);
-		return CMD_WARNING_CONFIG_FAILED;
-	}
-
-	asfilter = as_filter_make(regex, regstr, type);
-
-	XFREE(MTYPE_TMP, regstr);
-
-	/* Install new filter to the access_list. */
-	aslist = as_list_get(alname);
-
-	if (seqnum == ASPATH_SEQ_NUMBER_AUTO)
-		seqnum = bgp_alist_new_seq_get(aslist);
-
-	asfilter->seq = seqnum;
-
-	/* Duplicate insertion check. */;
-	if (as_list_dup_check(aslist, asfilter))
-		as_filter_free(asfilter);
-	else
-		as_list_filter_add(aslist, asfilter);
-
-	return CMD_SUCCESS;
-}
-
-DEFUN(no_as_path, no_bgp_as_path_cmd,
-      "no bgp as-path access-list AS_PATH_FILTER_NAME [seq (0-4294967295)] <deny|permit> LINE...",
-      NO_STR
-      BGP_STR
-      "BGP autonomous system path filter\n"
-      "Specify an access list name\n"
-      "Regular expression access list name\n"
-      "Sequence number of an entry\n"
-      "Sequence number\n"
-      "Specify packets to reject\n"
-      "Specify packets to forward\n"
-      "A regular-expression (1234567890_^|[,{}() ]$*+.?-\\) to match the BGP AS paths\n")
-{
-	int idx = 0;
-	enum as_filter_type type;
-	struct as_filter *asfilter;
-	struct as_list *aslist;
-	char *regstr;
-	regex_t *regex;
-
-	char *aslistname =
-		argv_find(argv, argc, "AS_PATH_FILTER_NAME", &idx) ? argv[idx]->arg : NULL;
-
-	/* Lookup AS list from AS path list. */
-	aslist = as_list_lookup(aslistname);
-	if (aslist == NULL) {
-		vty_out(vty, "bgp as-path access-list %s doesn't exist\n",
-			aslistname);
-		return CMD_WARNING_CONFIG_FAILED;
-	}
-
-	/* Check the filter type. */
-	if (argv_find(argv, argc, "permit", &idx))
-		type = AS_FILTER_PERMIT;
-	else if (argv_find(argv, argc, "deny", &idx))
-		type = AS_FILTER_DENY;
-	else {
-		vty_out(vty, "filter type must be [permit|deny]\n");
-		return CMD_WARNING_CONFIG_FAILED;
-	}
-
-	/* Compile AS path. */
-	argv_find(argv, argc, "LINE", &idx);
-	regstr = argv_concat(argv, argc, idx);
-
-	if (!config_bgp_aspath_validate(regstr)) {
-		vty_out(vty, "Invalid character in as-path access-list %s\n",
-			regstr);
-		return CMD_WARNING_CONFIG_FAILED;
-	}
-
-	regex = bgp_regcomp(regstr);
-	if (!regex) {
-		vty_out(vty, "can't compile regexp %s\n", regstr);
-		XFREE(MTYPE_TMP, regstr);
-		return CMD_WARNING_CONFIG_FAILED;
-	}
-
-	/* Lookup asfilter. */
-	asfilter = as_filter_lookup(aslist, regstr, type);
-
-	bgp_regex_free(regex);
-
-	if (asfilter == NULL) {
-		vty_out(vty, "Regex entered %s does not exist\n", regstr);
-		XFREE(MTYPE_TMP, regstr);
-		return CMD_WARNING_CONFIG_FAILED;
-	}
-
-	XFREE(MTYPE_TMP, regstr);
-
-	as_list_filter_delete(aslist, asfilter);
-
-	return CMD_SUCCESS;
-}
-
-DEFUN (no_as_path_all,
-       no_bgp_as_path_all_cmd,
-       "no bgp as-path access-list AS_PATH_FILTER_NAME",
-       NO_STR
-       BGP_STR
-       "BGP autonomous system path filter\n"
-       "Specify an access list name\n"
-       "Regular expression access list name\n")
-{
-	int idx_word = 4;
-	struct as_list *aslist;
-
-	aslist = as_list_lookup(argv[idx_word]->arg);
-	if (aslist == NULL) {
-		vty_out(vty, "bgp as-path access-list %s doesn't exist\n",
-			argv[idx_word]->arg);
-		return CMD_WARNING_CONFIG_FAILED;
-	}
-
-	as_list_delete(aslist);
-
-	/* Run hook function. */
-	if (as_list_master.delete_hook)
-		(*as_list_master.delete_hook)(argv[idx_word]->arg);
-
-	return CMD_SUCCESS;
-}
-
-DEFUN(ip_as_path, ip_as_path_cmd,
+DEFUN(as_path, ip_as_path_cmd,
       "ip as-path access-list AS_PATH_FILTER_NAME [seq (0-4294967295)] <deny|permit> LINE...",
       "ip as-path (Command for backward compatibility with FRR 6.0.3)\n"
       "BGP autonomous system path filter\n"
@@ -684,7 +510,7 @@ DEFUN(ip_as_path, ip_as_path_cmd,
 	return CMD_SUCCESS;
 }
 
-DEFUN(no_ip_as_path, no_ip_as_path_cmd,
+DEFUN(no_as_path, no_ip_as_path_cmd,
       "no ip as-path access-list AS_PATH_FILTER_NAME [seq (0-4294967295)] <deny|permit> LINE...",
       NO_STR
       "ip as-path (Command for backward compatibility with FRR 6.0.3)\n"
@@ -716,51 +542,51 @@ DEFUN(no_ip_as_path, no_ip_as_path_cmd,
 	}
 
 	/* Check the filter type. */
-	if (argv_find(argv, argc, "permit", &idx))\
-                type = AS_FILTER_PERMIT;
-        else if (argv_find(argv, argc, "deny", &idx))
-                type = AS_FILTER_DENY;
-        else {
-                vty_out(vty, "filter type must be [permit|deny]\n");
-                return CMD_WARNING_CONFIG_FAILED;
-        }
+	if (argv_find(argv, argc, "permit", &idx))
+		type = AS_FILTER_PERMIT;
+	else if (argv_find(argv, argc, "deny", &idx))
+		type = AS_FILTER_DENY;
+	else {
+		vty_out(vty, "filter type must be [permit|deny]\n");
+		return CMD_WARNING_CONFIG_FAILED;
+	}
 
-        /* Compile AS path. */
-        argv_find(argv, argc, "LINE", &idx);
-        regstr = argv_concat(argv, argc, idx);
+	/* Compile AS path. */
+	argv_find(argv, argc, "LINE", &idx);
+	regstr = argv_concat(argv, argc, idx);
 
-        if (!config_bgp_aspath_validate(regstr)) {
-                vty_out(vty, "Invalid character in as-path access-list %s\n",
-                        regstr);
-                return CMD_WARNING_CONFIG_FAILED;
-        }
+	if (!config_bgp_aspath_validate(regstr)) {
+		vty_out(vty, "Invalid character in as-path access-list %s\n",
+			regstr);
+		return CMD_WARNING_CONFIG_FAILED;
+	}
 
-        regex = bgp_regcomp(regstr);
-        if (!regex) {
-                vty_out(vty, "can't compile regexp %s\n", regstr);
-                XFREE(MTYPE_TMP, regstr);
-                return CMD_WARNING_CONFIG_FAILED;
-        }
+	regex = bgp_regcomp(regstr);
+	if (!regex) {
+		vty_out(vty, "can't compile regexp %s\n", regstr);
+		XFREE(MTYPE_TMP, regstr);
+		return CMD_WARNING_CONFIG_FAILED;
+	}
 
-        /* Lookup asfilter. */
-        asfilter = as_filter_lookup(aslist, regstr, type);
+	/* Lookup asfilter. */
+	asfilter = as_filter_lookup(aslist, regstr, type);
 
-        bgp_regex_free(regex);
+	bgp_regex_free(regex);
 
-        if (asfilter == NULL) {
-                vty_out(vty, "Regex entered %s does not exist\n", regstr);
-                XFREE(MTYPE_TMP, regstr);
-                return CMD_WARNING_CONFIG_FAILED;
-        }
+	if (asfilter == NULL) {
+		vty_out(vty, "Regex entered %s does not exist\n", regstr);
+		XFREE(MTYPE_TMP, regstr);
+		return CMD_WARNING_CONFIG_FAILED;
+	}
 
-        XFREE(MTYPE_TMP, regstr);
+	XFREE(MTYPE_TMP, regstr);
 
-        as_list_filter_delete(aslist, asfilter);
+	as_list_filter_delete(aslist, asfilter);
 
-        return CMD_SUCCESS;
+	return CMD_SUCCESS;
 }
 
-DEFUN (no_ip_as_path_all,
+DEFUN (no_as_path_all,
        no_ip_as_path_all_cmd,
        "no ip as-path access-list AS_PATH_FILTER_NAME",
        NO_STR
@@ -769,23 +595,23 @@ DEFUN (no_ip_as_path_all,
        "Specify an access list name\n"
        "Regular expression access list name\n")
 {
-        int idx_word = 4;
-        struct as_list *aslist;
+	int idx_word = 4;
+	struct as_list *aslist;
 
-        aslist = as_list_lookup(argv[idx_word]->arg);
-        if (aslist == NULL) {
-                vty_out(vty, "ip as-path access-list %s doesn't exist\n",
-                        argv[idx_word]->arg);
-                return CMD_WARNING_CONFIG_FAILED;
-        }
+	aslist = as_list_lookup(argv[idx_word]->arg);
+	if (aslist == NULL) {
+		vty_out(vty, "ip as-path access-list %s doesn't exist\n",
+			argv[idx_word]->arg);
+		return CMD_WARNING_CONFIG_FAILED;
+	}
 
-        as_list_delete(aslist);
+	as_list_delete(aslist);
 
-        /* Run hook function. */
-        if (as_list_master.delete_hook)
-                (*as_list_master.delete_hook)(argv[idx_word]->arg);
+	/* Run hook function. */
+	if (as_list_master.delete_hook)
+		(*as_list_master.delete_hook)(argv[idx_word]->arg);
 
-        return CMD_SUCCESS;
+	return CMD_SUCCESS;
 }
 
 static void as_list_show(struct vty *vty, struct as_list *aslist,
@@ -903,7 +729,7 @@ static int config_write_as_list(struct vty *vty)
 		for (asfilter = aslist->head; asfilter;
 		     asfilter = asfilter->next) {
 			vty_out(vty,
-				"bgp as-path access-list %s seq %" PRId64
+				"ip as-path access-list %s seq %" PRId64
 				" %s %s\n",
 				aslist->name, asfilter->seq,
 				filter_type_str(asfilter->type),
@@ -939,10 +765,6 @@ static const struct cmd_variable_handler aspath_filter_handlers[] = {
 void bgp_filter_init(void)
 {
 	install_node(&as_list_node);
-
-	install_element(CONFIG_NODE, &bgp_as_path_cmd);
-	install_element(CONFIG_NODE, &no_bgp_as_path_cmd);
-	install_element(CONFIG_NODE, &no_bgp_as_path_all_cmd);
 
         /* Install elements for FRR 6.0.3 backward compatibility */
         install_element(CONFIG_NODE, &ip_as_path_cmd);

--- a/bgpd/bgp_filter.c
+++ b/bgpd/bgp_filter.c
@@ -614,6 +614,180 @@ DEFUN (no_as_path_all,
 	return CMD_SUCCESS;
 }
 
+DEFUN(ip_as_path, ip_as_path_cmd,
+      "ip as-path access-list AS_PATH_FILTER_NAME [seq (0-4294967295)] <deny|permit> LINE...",
+      "ip as-path (Command for backward compatibility with FRR 6.0.3)\n"
+      "BGP autonomous system path filter\n"
+      "Specify an access list name\n"
+      "Regular expression access list name\n"
+      "Sequence number of an entry\n"
+      "Sequence number\n"
+      "Specify packets to reject\n"
+      "Specify packets to forward\n"
+      "A regular-expression (1234567890_^|[,{}() ]$*+.?-\\) to match the BGP AS paths\n")
+{
+	int idx = 0;
+	enum as_filter_type type;
+	struct as_filter *asfilter;
+	struct as_list *aslist;
+	regex_t *regex;
+	char *regstr;
+	int64_t seqnum = ASPATH_SEQ_NUMBER_AUTO;
+
+	/* Retrieve access list name */
+	argv_find(argv, argc, "AS_PATH_FILTER_NAME", &idx);
+	char *alname = argv[idx]->arg;
+
+	if (argv_find(argv, argc, "(0-4294967295)", &idx))
+		seqnum = (int64_t)atol(argv[idx]->arg);
+
+	/* Check the filter type. */
+	type = argv_find(argv, argc, "deny", &idx) ? AS_FILTER_DENY
+						   : AS_FILTER_PERMIT;
+
+	/* Check AS path regex. */
+	argv_find(argv, argc, "LINE", &idx);
+	regstr = argv_concat(argv, argc, idx);
+
+	regex = bgp_regcomp(regstr);
+	if (!regex) {
+		vty_out(vty, "can't compile regexp %s\n", regstr);
+		XFREE(MTYPE_TMP, regstr);
+		return CMD_WARNING_CONFIG_FAILED;
+	}
+
+	if (!config_bgp_aspath_validate(regstr)) {
+		vty_out(vty, "Invalid character in as-path access-list %s\n",
+			regstr);
+		XFREE(MTYPE_TMP, regstr);
+		return CMD_WARNING_CONFIG_FAILED;
+	}
+
+	asfilter = as_filter_make(regex, regstr, type);
+
+	XFREE(MTYPE_TMP, regstr);
+
+	/* Install new filter to the access_list. */
+	aslist = as_list_get(alname);
+
+	if (seqnum == ASPATH_SEQ_NUMBER_AUTO)
+		seqnum = bgp_alist_new_seq_get(aslist);
+
+	asfilter->seq = seqnum;
+
+	/* Duplicate insertion check. */;
+	if (as_list_dup_check(aslist, asfilter))
+		as_filter_free(asfilter);
+	else
+		as_list_filter_add(aslist, asfilter);
+
+	return CMD_SUCCESS;
+}
+
+DEFUN(no_ip_as_path, no_ip_as_path_cmd,
+      "no ip as-path access-list AS_PATH_FILTER_NAME [seq (0-4294967295)] <deny|permit> LINE...",
+      NO_STR
+      "ip as-path (Command for backward compatibility with FRR 6.0.3)\n"
+      "BGP autonomous system path filter\n"
+      "Specify an access list name\n"
+      "Regular expression access list name\n"
+      "Sequence number of an entry\n"
+      "Sequence number\n"
+      "Specify packets to reject\n"
+      "Specify packets to forward\n"
+      "A regular-expression (1234567890_^|[,{}() ]$*+.?-\\) to match the BGP AS paths\n")
+{
+	int idx = 0;
+	enum as_filter_type type;
+	struct as_filter *asfilter;
+	struct as_list *aslist;
+	char *regstr;
+	regex_t *regex;
+
+	char *aslistname =
+		argv_find(argv, argc, "AS_PATH_FILTER_NAME", &idx) ? argv[idx]->arg : NULL;
+
+	/* Lookup AS list from AS path list. */
+	aslist = as_list_lookup(aslistname);
+	if (aslist == NULL) {
+		vty_out(vty, "ip as-path access-list %s doesn't exist\n",
+			aslistname);
+		return CMD_WARNING_CONFIG_FAILED;
+	}
+
+	/* Check the filter type. */
+	if (argv_find(argv, argc, "permit", &idx))\
+                type = AS_FILTER_PERMIT;
+        else if (argv_find(argv, argc, "deny", &idx))
+                type = AS_FILTER_DENY;
+        else {
+                vty_out(vty, "filter type must be [permit|deny]\n");
+                return CMD_WARNING_CONFIG_FAILED;
+        }
+
+        /* Compile AS path. */
+        argv_find(argv, argc, "LINE", &idx);
+        regstr = argv_concat(argv, argc, idx);
+
+        if (!config_bgp_aspath_validate(regstr)) {
+                vty_out(vty, "Invalid character in as-path access-list %s\n",
+                        regstr);
+                return CMD_WARNING_CONFIG_FAILED;
+        }
+
+        regex = bgp_regcomp(regstr);
+        if (!regex) {
+                vty_out(vty, "can't compile regexp %s\n", regstr);
+                XFREE(MTYPE_TMP, regstr);
+                return CMD_WARNING_CONFIG_FAILED;
+        }
+
+        /* Lookup asfilter. */
+        asfilter = as_filter_lookup(aslist, regstr, type);
+
+        bgp_regex_free(regex);
+
+        if (asfilter == NULL) {
+                vty_out(vty, "Regex entered %s does not exist\n", regstr);
+                XFREE(MTYPE_TMP, regstr);
+                return CMD_WARNING_CONFIG_FAILED;
+        }
+
+        XFREE(MTYPE_TMP, regstr);
+
+        as_list_filter_delete(aslist, asfilter);
+
+        return CMD_SUCCESS;
+}
+
+DEFUN (no_ip_as_path_all,
+       no_ip_as_path_all_cmd,
+       "no ip as-path access-list AS_PATH_FILTER_NAME",
+       NO_STR
+       "ip as-path (Command for backward compatibility with FRR 6.0.3)\n"
+       "BGP autonomous system path filter\n"
+       "Specify an access list name\n"
+       "Regular expression access list name\n")
+{
+        int idx_word = 4;
+        struct as_list *aslist;
+
+        aslist = as_list_lookup(argv[idx_word]->arg);
+        if (aslist == NULL) {
+                vty_out(vty, "ip as-path access-list %s doesn't exist\n",
+                        argv[idx_word]->arg);
+                return CMD_WARNING_CONFIG_FAILED;
+        }
+
+        as_list_delete(aslist);
+
+        /* Run hook function. */
+        if (as_list_master.delete_hook)
+                (*as_list_master.delete_hook)(argv[idx_word]->arg);
+
+        return CMD_SUCCESS;
+}
+
 static void as_list_show(struct vty *vty, struct as_list *aslist,
 			 json_object *json)
 {
@@ -769,6 +943,11 @@ void bgp_filter_init(void)
 	install_element(CONFIG_NODE, &bgp_as_path_cmd);
 	install_element(CONFIG_NODE, &no_bgp_as_path_cmd);
 	install_element(CONFIG_NODE, &no_bgp_as_path_all_cmd);
+
+        /* Install elements for FRR 6.0.3 backward compatibility */
+        install_element(CONFIG_NODE, &ip_as_path_cmd);
+        install_element(CONFIG_NODE, &no_ip_as_path_cmd);
+        install_element(CONFIG_NODE, &no_ip_as_path_all_cmd);
 
 	install_element(VIEW_NODE, &show_bgp_as_path_access_list_cmd);
 	install_element(VIEW_NODE, &show_ip_as_path_access_list_cmd);

--- a/bgpd/bgp_filter.c
+++ b/bgpd/bgp_filter.c
@@ -767,9 +767,9 @@ void bgp_filter_init(void)
 	install_node(&as_list_node);
 
         /* Install elements for FRR 6.0.3 backward compatibility */
-        install_element(CONFIG_NODE, &ip_as_path_cmd);
-        install_element(CONFIG_NODE, &no_ip_as_path_cmd);
-        install_element(CONFIG_NODE, &no_ip_as_path_all_cmd);
+	install_element(CONFIG_NODE, &ip_as_path_cmd);
+	install_element(CONFIG_NODE, &no_ip_as_path_cmd);
+	install_element(CONFIG_NODE, &no_ip_as_path_all_cmd);
 
 	install_element(VIEW_NODE, &show_bgp_as_path_access_list_cmd);
 	install_element(VIEW_NODE, &show_ip_as_path_access_list_cmd);

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -20356,6 +20356,117 @@ ALIAS(no_community_list_standard_all, no_bgp_community_list_standard_all_list_cm
       "Add an standard community-list entry\n"
       "Community list name\n")
 
+/*Added for Backwards compatibility with 6.0.3. community-list standard */
+DEFUN (ip_community_list_standard,
+       ip_community_list_standard_cmd,
+       "ip community-list <(1-99)|standard COMMUNITY_LIST_NAME> [seq (0-4294967295)] <deny|permit> AA:NN...",
+       "ip community (Legacy syntax for backward compatibility with 6.0.3)\n"
+       COMMUNITY_LIST_STR
+       "Community list number (standard)\n"
+       "Add an standard community-list entry\n"
+       "Community list name\n"
+       "Sequence number of an entry\n"
+       "Sequence number\n"
+       "Specify community to reject\n"
+       "Specify community to accept\n"
+       COMMUNITY_VAL_STR)
+{
+	char *cl_name_or_number = NULL;
+	char *seq = NULL;
+	int direct = 0;
+	int style = COMMUNITY_LIST_STANDARD;
+	int idx = 0;
+
+	if (argv_find(argv, argc, "(0-4294967295)", &idx))
+		seq = argv[idx]->arg;
+
+	idx = 0;
+	argv_find(argv, argc, "(1-99)", &idx);
+	argv_find(argv, argc, "COMMUNITY_LIST_NAME", &idx);
+	cl_name_or_number = argv[idx]->arg;
+	direct = argv_find(argv, argc, "permit", &idx) ? COMMUNITY_PERMIT
+						       : COMMUNITY_DENY;
+	argv_find(argv, argc, "AA:NN", &idx);
+	char *str = argv_concat(argv, argc, idx);
+
+	int ret = community_list_set(bgp_clist, cl_name_or_number, str, seq,
+				     direct, style);
+
+	XFREE(MTYPE_TMP, str);
+
+	if (ret < 0) {
+		/* Display error string.  */
+		community_list_perror(vty, ret);
+		return CMD_WARNING_CONFIG_FAILED;
+	}
+
+	return CMD_SUCCESS;
+}
+
+DEFUN (no_ip_community_list_standard_all,
+       no_ip_community_list_standard_all_cmd,
+       "no ip community-list <(1-99)|standard COMMUNITY_LIST_NAME> [seq (0-4294967295)] <deny|permit> AA:NN...",
+       NO_STR
+       "ip community (Legacy syntax for backward compatibility with 6.0.3)\n"
+       COMMUNITY_LIST_STR
+       "Community list number (standard)\n"
+       "Add an standard community-list entry\n"
+       "Community list name\n"
+       "Sequence number of an entry\n"
+       "Sequence number\n"
+       "Specify community to reject\n"
+       "Specify community to accept\n"
+       COMMUNITY_VAL_STR)
+{
+	char *cl_name_or_number = NULL;
+	char *str = NULL;
+	int direct = 0;
+	int style = COMMUNITY_LIST_STANDARD;
+	char *seq = NULL;
+	int idx = 0;
+
+	if (argv_find(argv, argc, "(0-4294967295)", &idx))
+		seq = argv[idx]->arg;
+
+	idx = 0;
+	argv_find(argv, argc, "permit", &idx);
+	argv_find(argv, argc, "deny", &idx);
+
+	if (idx) {
+		direct = argv_find(argv, argc, "permit", &idx)
+				 ? COMMUNITY_PERMIT
+				 : COMMUNITY_DENY;
+
+		idx = 0;
+		argv_find(argv, argc, "AA:NN", &idx);
+		str = argv_concat(argv, argc, idx);
+	}
+
+	idx = 0;
+	argv_find(argv, argc, "(1-99)", &idx);
+	argv_find(argv, argc, "COMMUNITY_LIST_NAME", &idx);
+	cl_name_or_number = argv[idx]->arg;
+
+	int ret = community_list_unset(bgp_clist, cl_name_or_number, str, seq,
+				       direct, style);
+
+	XFREE(MTYPE_TMP, str);
+
+	if (ret < 0) {
+		community_list_perror(vty, ret);
+		return CMD_WARNING_CONFIG_FAILED;
+	}
+
+	return CMD_SUCCESS;
+}
+
+ALIAS(no_ip_community_list_standard_all, no_ip_community_list_standard_all_list_cmd,
+      "no ip community-list <(1-99)|standard COMMUNITY_LIST_NAME>",
+      NO_STR "ip community (Legacy syntax for backward compatibility with 6.0.3)\n" COMMUNITY_LIST_STR
+      "Community list number (standard)\n"
+      "Add an standard community-list entry\n"
+      "Community list name\n")
+
 /*community-list expanded */
 DEFUN (community_list_expanded_all,
        bgp_community_list_expanded_all_cmd,
@@ -20979,6 +21090,52 @@ DEFUN (extcommunity_list_standard,
 	return CMD_SUCCESS;
 }
 
+DEFUN (ip_extcommunity_list_standard,
+       ip_extcommunity_list_standard_cmd,
+       "ip extcommunity-list <(1-99)|standard EXTCOMMUNITY_LIST_NAME> [seq (0-4294967295)] <deny|permit> AA:NN...",
+       "ip extcommunity-list (Command for backwards compatibility with FRR 6.0.3)\n"
+       EXTCOMMUNITY_LIST_STR
+       "Extended Community list number (standard)\n"
+       "Specify standard extcommunity-list\n"
+       "Community list name\n"
+       "Sequence number of an entry\n"
+       "Sequence number\n"
+       "Specify community to reject\n"
+       "Specify community to accept\n"
+       EXTCOMMUNITY_VAL_STR)
+{
+	int style = EXTCOMMUNITY_LIST_STANDARD;
+	int direct = 0;
+	char *cl_number_or_name = NULL;
+	char *seq = NULL;
+
+	int idx = 0;
+
+	argv_find(argv, argc, "(1-99)", &idx);
+	argv_find(argv, argc, "EXTCOMMUNITY_LIST_NAME", &idx);
+	cl_number_or_name = argv[idx]->arg;
+
+	if (argv_find(argv, argc, "(0-4294967295)", &idx))
+		seq = argv[idx]->arg;
+
+	direct = argv_find(argv, argc, "permit", &idx) ? COMMUNITY_PERMIT
+						       : COMMUNITY_DENY;
+	argv_find(argv, argc, "AA:NN", &idx);
+	char *str = argv_concat(argv, argc, idx);
+
+	int ret = extcommunity_list_set(bgp_clist, cl_number_or_name, str, seq,
+					direct, style);
+
+	XFREE(MTYPE_TMP, str);
+
+	if (ret < 0) {
+		community_list_perror(vty, ret);
+		return CMD_WARNING_CONFIG_FAILED;
+	}
+
+	return CMD_SUCCESS;
+}
+
 DEFUN (extcommunity_list_name_expanded,
        bgp_extcommunity_list_name_expanded_cmd,
        "bgp extcommunity-list <(100-500)|expanded EXTCOMMUNITY_LIST_NAME> [seq (0-4294967295)] <deny|permit> LINE...",
@@ -21084,6 +21241,70 @@ ALIAS(no_extcommunity_list_standard_all,
       no_bgp_extcommunity_list_standard_all_list_cmd,
       "no bgp extcommunity-list <(1-99)|standard EXTCOMMUNITY_LIST_NAME>",
       NO_STR BGP_STR EXTCOMMUNITY_LIST_STR
+      "Extended Community list number (standard)\n"
+      "Specify standard extcommunity-list\n"
+      "Community list name\n")
+
+DEFUN (no_ip_extcommunity_list_standard_all,
+       no_ip_extcommunity_list_standard_all_cmd,
+       "no ip extcommunity-list <(1-99)|standard EXTCOMMUNITY_LIST_NAME> [seq (0-4294967295)] <deny|permit> AA:NN...",
+       NO_STR
+       "ip extcommunity-list (Command for backward compatibility with FRR 6.0.3)\n"
+       EXTCOMMUNITY_LIST_STR
+       "Extended Community list number (standard)\n"
+       "Specify standard extcommunity-list\n"
+       "Community list name\n"
+       "Sequence number of an entry\n"
+       "Sequence number\n"
+       "Specify community to reject\n"
+       "Specify community to accept\n"
+       EXTCOMMUNITY_VAL_STR)
+{
+	int style = EXTCOMMUNITY_LIST_STANDARD;
+	int direct = 0;
+	char *cl_number_or_name = NULL;
+	char *str = NULL;
+	char *seq = NULL;
+	int idx = 0;
+
+	if (argv_find(argv, argc, "(0-4294967295)", &idx))
+		seq = argv[idx]->arg;
+
+	idx = 0;
+	argv_find(argv, argc, "permit", &idx);
+	argv_find(argv, argc, "deny", &idx);
+	if (idx) {
+		direct = argv_find(argv, argc, "permit", &idx)
+				 ? COMMUNITY_PERMIT
+				 : COMMUNITY_DENY;
+
+		idx = 0;
+		argv_find(argv, argc, "AA:NN", &idx);
+		str = argv_concat(argv, argc, idx);
+	}
+
+	idx = 0;
+	argv_find(argv, argc, "(1-99)", &idx);
+	argv_find(argv, argc, "EXTCOMMUNITY_LIST_NAME", &idx);
+	cl_number_or_name = argv[idx]->arg;
+
+	int ret = extcommunity_list_unset(bgp_clist, cl_number_or_name, str,
+					  seq, direct, style);
+
+	XFREE(MTYPE_TMP, str);
+
+	if (ret < 0) {
+		community_list_perror(vty, ret);
+		return CMD_WARNING_CONFIG_FAILED;
+	}
+
+	return CMD_SUCCESS;
+}
+
+ALIAS(no_ip_extcommunity_list_standard_all,
+      no_ip_extcommunity_list_standard_all_list_cmd,
+      "no ip extcommunity-list <(1-99)|standard EXTCOMMUNITY_LIST_NAME>",
+      NO_STR "ip extcommunity-list (Command for backward compatibility with FRR 6.0.3)\n" EXTCOMMUNITY_LIST_STR
       "Extended Community list number (standard)\n"
       "Specify standard extcommunity-list\n"
       "Community list name\n")
@@ -21341,6 +21562,11 @@ static void community_list_vty(void)
 	install_element(VIEW_NODE, &show_bgp_community_list_cmd);
 	install_element(VIEW_NODE, &show_bgp_community_list_arg_cmd);
 
+	/* community list Commands for Backward compatibility with FRR 6.0.3 */
+	install_element(CONFIG_NODE, &ip_community_list_standard_cmd);
+	install_element(CONFIG_NODE, &no_ip_community_list_standard_all_cmd);
+	install_element(CONFIG_NODE, &no_ip_community_list_standard_all_list_cmd);
+
 	/* Extcommunity-list.  */
 	install_element(CONFIG_NODE, &bgp_extcommunity_list_standard_cmd);
 	install_element(CONFIG_NODE, &bgp_extcommunity_list_name_expanded_cmd);
@@ -21352,6 +21578,11 @@ static void community_list_vty(void)
 			&no_bgp_extcommunity_list_expanded_all_list_cmd);
 	install_element(VIEW_NODE, &show_bgp_extcommunity_list_cmd);
 	install_element(VIEW_NODE, &show_bgp_extcommunity_list_arg_cmd);
+
+	/* ext-community list Commands for Backward compatibility with FRR 6.0.3 */
+	install_element(CONFIG_NODE, &ip_extcommunity_list_standard_cmd);
+	install_element(CONFIG_NODE, &no_ip_extcommunity_list_standard_all_cmd);
+	install_element(CONFIG_NODE, &no_ip_extcommunity_list_standard_all_list_cmd);
 
 	/* Large Community List */
 	install_element(CONFIG_NODE, &bgp_lcommunity_list_standard_cmd);

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -20245,119 +20245,8 @@ static void community_list_perror(struct vty *vty, int ret)
 /* "community-list" keyword help string.  */
 #define COMMUNITY_LIST_STR "Add a community list entry\n"
 
-/*community-list standard */
-DEFUN (community_list_standard,
-       bgp_community_list_standard_cmd,
-       "bgp community-list <(1-99)|standard COMMUNITY_LIST_NAME> [seq (0-4294967295)] <deny|permit> AA:NN...",
-       BGP_STR
-       COMMUNITY_LIST_STR
-       "Community list number (standard)\n"
-       "Add an standard community-list entry\n"
-       "Community list name\n"
-       "Sequence number of an entry\n"
-       "Sequence number\n"
-       "Specify community to reject\n"
-       "Specify community to accept\n"
-       COMMUNITY_VAL_STR)
-{
-	char *cl_name_or_number = NULL;
-	char *seq = NULL;
-	int direct = 0;
-	int style = COMMUNITY_LIST_STANDARD;
-	int idx = 0;
-
-	if (argv_find(argv, argc, "(0-4294967295)", &idx))
-		seq = argv[idx]->arg;
-
-	idx = 0;
-	argv_find(argv, argc, "(1-99)", &idx);
-	argv_find(argv, argc, "COMMUNITY_LIST_NAME", &idx);
-	cl_name_or_number = argv[idx]->arg;
-	direct = argv_find(argv, argc, "permit", &idx) ? COMMUNITY_PERMIT
-						       : COMMUNITY_DENY;
-	argv_find(argv, argc, "AA:NN", &idx);
-	char *str = argv_concat(argv, argc, idx);
-
-	int ret = community_list_set(bgp_clist, cl_name_or_number, str, seq,
-				     direct, style);
-
-	XFREE(MTYPE_TMP, str);
-
-	if (ret < 0) {
-		/* Display error string.  */
-		community_list_perror(vty, ret);
-		return CMD_WARNING_CONFIG_FAILED;
-	}
-
-	return CMD_SUCCESS;
-}
-
-DEFUN (no_community_list_standard_all,
-       no_bgp_community_list_standard_all_cmd,
-       "no bgp community-list <(1-99)|standard COMMUNITY_LIST_NAME> [seq (0-4294967295)] <deny|permit> AA:NN...",
-       NO_STR
-       BGP_STR
-       COMMUNITY_LIST_STR
-       "Community list number (standard)\n"
-       "Add an standard community-list entry\n"
-       "Community list name\n"
-       "Sequence number of an entry\n"
-       "Sequence number\n"
-       "Specify community to reject\n"
-       "Specify community to accept\n"
-       COMMUNITY_VAL_STR)
-{
-	char *cl_name_or_number = NULL;
-	char *str = NULL;
-	int direct = 0;
-	int style = COMMUNITY_LIST_STANDARD;
-	char *seq = NULL;
-	int idx = 0;
-
-	if (argv_find(argv, argc, "(0-4294967295)", &idx))
-		seq = argv[idx]->arg;
-
-	idx = 0;
-	argv_find(argv, argc, "permit", &idx);
-	argv_find(argv, argc, "deny", &idx);
-
-	if (idx) {
-		direct = argv_find(argv, argc, "permit", &idx)
-				 ? COMMUNITY_PERMIT
-				 : COMMUNITY_DENY;
-
-		idx = 0;
-		argv_find(argv, argc, "AA:NN", &idx);
-		str = argv_concat(argv, argc, idx);
-	}
-
-	idx = 0;
-	argv_find(argv, argc, "(1-99)", &idx);
-	argv_find(argv, argc, "COMMUNITY_LIST_NAME", &idx);
-	cl_name_or_number = argv[idx]->arg;
-
-	int ret = community_list_unset(bgp_clist, cl_name_or_number, str, seq,
-				       direct, style);
-
-	XFREE(MTYPE_TMP, str);
-
-	if (ret < 0) {
-		community_list_perror(vty, ret);
-		return CMD_WARNING_CONFIG_FAILED;
-	}
-
-	return CMD_SUCCESS;
-}
-
-ALIAS(no_community_list_standard_all, no_bgp_community_list_standard_all_list_cmd,
-      "no bgp community-list <(1-99)|standard COMMUNITY_LIST_NAME>",
-      NO_STR BGP_STR COMMUNITY_LIST_STR
-      "Community list number (standard)\n"
-      "Add an standard community-list entry\n"
-      "Community list name\n")
-
 /*Added for Backwards compatibility with 6.0.3. community-list standard */
-DEFUN (ip_community_list_standard,
+DEFUN (community_list_standard,
        ip_community_list_standard_cmd,
        "ip community-list <(1-99)|standard COMMUNITY_LIST_NAME> [seq (0-4294967295)] <deny|permit> AA:NN...",
        "ip community (Legacy syntax for backward compatibility with 6.0.3)\n"
@@ -20403,7 +20292,7 @@ DEFUN (ip_community_list_standard,
 	return CMD_SUCCESS;
 }
 
-DEFUN (no_ip_community_list_standard_all,
+DEFUN (no_community_list_standard_all,
        no_ip_community_list_standard_all_cmd,
        "no ip community-list <(1-99)|standard COMMUNITY_LIST_NAME> [seq (0-4294967295)] <deny|permit> AA:NN...",
        NO_STR
@@ -20460,7 +20349,7 @@ DEFUN (no_ip_community_list_standard_all,
 	return CMD_SUCCESS;
 }
 
-ALIAS(no_ip_community_list_standard_all, no_ip_community_list_standard_all_list_cmd,
+ALIAS(no_community_list_standard_all, no_ip_community_list_standard_all_list_cmd,
       "no ip community-list <(1-99)|standard COMMUNITY_LIST_NAME>",
       NO_STR "ip community (Legacy syntax for backward compatibility with 6.0.3)\n" COMMUNITY_LIST_STR
       "Community list number (standard)\n"
@@ -20469,9 +20358,9 @@ ALIAS(no_ip_community_list_standard_all, no_ip_community_list_standard_all_list_
 
 /*community-list expanded */
 DEFUN (community_list_expanded_all,
-       bgp_community_list_expanded_all_cmd,
-       "bgp community-list <(100-500)|expanded COMMUNITY_LIST_NAME> [seq (0-4294967295)] <deny|permit> AA:NN...",
-       BGP_STR
+       ip_community_list_expanded_all_cmd,
+       "ip community-list <(100-500)|expanded COMMUNITY_LIST_NAME> [seq (0-4294967295)] <deny|permit> AA:NN...",
+       "ip community (Legacy syntax for backward compatibility with 6.0.3)\n"
        COMMUNITY_LIST_STR
        "Community list number (expanded)\n"
        "Add an expanded community-list entry\n"
@@ -20516,10 +20405,10 @@ DEFUN (community_list_expanded_all,
 }
 
 DEFUN (no_community_list_expanded_all,
-       no_bgp_community_list_expanded_all_cmd,
-       "no bgp community-list <(100-500)|expanded COMMUNITY_LIST_NAME> [seq (0-4294967295)] <deny|permit> AA:NN...",
+       no_ip_community_list_expanded_all_cmd,
+       "no ip community-list <(100-500)|expanded COMMUNITY_LIST_NAME> [seq (0-4294967295)] <deny|permit> AA:NN...",
        NO_STR
-       BGP_STR
+       "ip community (Legacy syntax for backward compatibility with 6.0.3)\n"
        COMMUNITY_LIST_STR
        "Community list number (expanded)\n"
        "Add an expanded community-list entry\n"
@@ -20573,9 +20462,9 @@ DEFUN (no_community_list_expanded_all,
 }
 
 ALIAS(no_community_list_expanded_all,
-      no_bgp_community_list_expanded_all_list_cmd,
-      "no bgp community-list <(100-500)|expanded COMMUNITY_LIST_NAME>",
-      NO_STR BGP_STR COMMUNITY_LIST_STR
+      no_ip_community_list_expanded_all_list_cmd,
+      "no ip community-list <(100-500)|expanded COMMUNITY_LIST_NAME>",
+      NO_STR "ip community (Legacy syntax for backward compatibility with 6.0.3)\n" COMMUNITY_LIST_STR
       "Community list number (expanded)\n"
       "Add an expanded community-list entry\n"
       "Community list name\n")
@@ -20628,10 +20517,10 @@ static void community_list_show(struct vty *vty, struct community_list *list)
 }
 
 DEFUN (show_community_list,
-       show_bgp_community_list_cmd,
-       "show bgp community-list",
+       show_ip_community_list_cmd,
+       "show ip community-list",
        SHOW_STR
-       BGP_STR
+       "ip community (Legacy syntax for backward compatibility with 6.0.3)\n"
        "List community-list\n")
 {
 	struct community_list *list;
@@ -20651,10 +20540,10 @@ DEFUN (show_community_list,
 }
 
 DEFUN (show_community_list_arg,
-       show_bgp_community_list_arg_cmd,
-       "show bgp community-list <(1-500)|COMMUNITY_LIST_NAME> detail",
+       show_ip_community_list_arg_cmd,
+       "show ip community-list <(1-500)|COMMUNITY_LIST_NAME> detail",
        SHOW_STR
-       BGP_STR
+       "ip community (Legacy syntax for backward compatibility with 6.0.3)\n"
        "List community-list\n"
        "Community-list number\n"
        "Community-list name\n"
@@ -21045,52 +20934,6 @@ DEFUN (show_lcommunity_list_arg,
 #define EXTCOMMUNITY_VAL_STR  "Extended community attribute in 'rt aa:nn_or_IPaddr:nn' OR 'soo aa:nn_or_IPaddr:nn' format\n"
 
 DEFUN (extcommunity_list_standard,
-       bgp_extcommunity_list_standard_cmd,
-       "bgp extcommunity-list <(1-99)|standard EXTCOMMUNITY_LIST_NAME> [seq (0-4294967295)] <deny|permit> AA:NN...",
-       BGP_STR
-       EXTCOMMUNITY_LIST_STR
-       "Extended Community list number (standard)\n"
-       "Specify standard extcommunity-list\n"
-       "Community list name\n"
-       "Sequence number of an entry\n"
-       "Sequence number\n"
-       "Specify community to reject\n"
-       "Specify community to accept\n"
-       EXTCOMMUNITY_VAL_STR)
-{
-	int style = EXTCOMMUNITY_LIST_STANDARD;
-	int direct = 0;
-	char *cl_number_or_name = NULL;
-	char *seq = NULL;
-
-	int idx = 0;
-
-	argv_find(argv, argc, "(1-99)", &idx);
-	argv_find(argv, argc, "EXTCOMMUNITY_LIST_NAME", &idx);
-	cl_number_or_name = argv[idx]->arg;
-
-	if (argv_find(argv, argc, "(0-4294967295)", &idx))
-		seq = argv[idx]->arg;
-
-	direct = argv_find(argv, argc, "permit", &idx) ? COMMUNITY_PERMIT
-						       : COMMUNITY_DENY;
-	argv_find(argv, argc, "AA:NN", &idx);
-	char *str = argv_concat(argv, argc, idx);
-
-	int ret = extcommunity_list_set(bgp_clist, cl_number_or_name, str, seq,
-					direct, style);
-
-	XFREE(MTYPE_TMP, str);
-
-	if (ret < 0) {
-		community_list_perror(vty, ret);
-		return CMD_WARNING_CONFIG_FAILED;
-	}
-
-	return CMD_SUCCESS;
-}
-
-DEFUN (ip_extcommunity_list_standard,
        ip_extcommunity_list_standard_cmd,
        "ip extcommunity-list <(1-99)|standard EXTCOMMUNITY_LIST_NAME> [seq (0-4294967295)] <deny|permit> AA:NN...",
        "ip extcommunity-list (Command for backwards compatibility with FRR 6.0.3)\n"
@@ -21137,9 +20980,9 @@ DEFUN (ip_extcommunity_list_standard,
 }
 
 DEFUN (extcommunity_list_name_expanded,
-       bgp_extcommunity_list_name_expanded_cmd,
-       "bgp extcommunity-list <(100-500)|expanded EXTCOMMUNITY_LIST_NAME> [seq (0-4294967295)] <deny|permit> LINE...",
-       BGP_STR
+       ip_extcommunity_list_name_expanded_cmd,
+       "ip extcommunity-list <(100-500)|expanded EXTCOMMUNITY_LIST_NAME> [seq (0-4294967295)] <deny|permit> LINE...",
+       "ip extcommunity-list (Command for backwards compatibility with FRR 6.0.3)\n"
        EXTCOMMUNITY_LIST_STR
        "Extended Community list number (expanded)\n"
        "Specify expanded extcommunity-list\n"
@@ -21182,70 +21025,6 @@ DEFUN (extcommunity_list_name_expanded,
 }
 
 DEFUN (no_extcommunity_list_standard_all,
-       no_bgp_extcommunity_list_standard_all_cmd,
-       "no bgp extcommunity-list <(1-99)|standard EXTCOMMUNITY_LIST_NAME> [seq (0-4294967295)] <deny|permit> AA:NN...",
-       NO_STR
-       BGP_STR
-       EXTCOMMUNITY_LIST_STR
-       "Extended Community list number (standard)\n"
-       "Specify standard extcommunity-list\n"
-       "Community list name\n"
-       "Sequence number of an entry\n"
-       "Sequence number\n"
-       "Specify community to reject\n"
-       "Specify community to accept\n"
-       EXTCOMMUNITY_VAL_STR)
-{
-	int style = EXTCOMMUNITY_LIST_STANDARD;
-	int direct = 0;
-	char *cl_number_or_name = NULL;
-	char *str = NULL;
-	char *seq = NULL;
-	int idx = 0;
-
-	if (argv_find(argv, argc, "(0-4294967295)", &idx))
-		seq = argv[idx]->arg;
-
-	idx = 0;
-	argv_find(argv, argc, "permit", &idx);
-	argv_find(argv, argc, "deny", &idx);
-	if (idx) {
-		direct = argv_find(argv, argc, "permit", &idx)
-				 ? COMMUNITY_PERMIT
-				 : COMMUNITY_DENY;
-
-		idx = 0;
-		argv_find(argv, argc, "AA:NN", &idx);
-		str = argv_concat(argv, argc, idx);
-	}
-
-	idx = 0;
-	argv_find(argv, argc, "(1-99)", &idx);
-	argv_find(argv, argc, "EXTCOMMUNITY_LIST_NAME", &idx);
-	cl_number_or_name = argv[idx]->arg;
-
-	int ret = extcommunity_list_unset(bgp_clist, cl_number_or_name, str,
-					  seq, direct, style);
-
-	XFREE(MTYPE_TMP, str);
-
-	if (ret < 0) {
-		community_list_perror(vty, ret);
-		return CMD_WARNING_CONFIG_FAILED;
-	}
-
-	return CMD_SUCCESS;
-}
-
-ALIAS(no_extcommunity_list_standard_all,
-      no_bgp_extcommunity_list_standard_all_list_cmd,
-      "no bgp extcommunity-list <(1-99)|standard EXTCOMMUNITY_LIST_NAME>",
-      NO_STR BGP_STR EXTCOMMUNITY_LIST_STR
-      "Extended Community list number (standard)\n"
-      "Specify standard extcommunity-list\n"
-      "Community list name\n")
-
-DEFUN (no_ip_extcommunity_list_standard_all,
        no_ip_extcommunity_list_standard_all_cmd,
        "no ip extcommunity-list <(1-99)|standard EXTCOMMUNITY_LIST_NAME> [seq (0-4294967295)] <deny|permit> AA:NN...",
        NO_STR
@@ -21301,7 +21080,7 @@ DEFUN (no_ip_extcommunity_list_standard_all,
 	return CMD_SUCCESS;
 }
 
-ALIAS(no_ip_extcommunity_list_standard_all,
+ALIAS(no_extcommunity_list_standard_all,
       no_ip_extcommunity_list_standard_all_list_cmd,
       "no ip extcommunity-list <(1-99)|standard EXTCOMMUNITY_LIST_NAME>",
       NO_STR "ip extcommunity-list (Command for backward compatibility with FRR 6.0.3)\n" EXTCOMMUNITY_LIST_STR
@@ -21310,10 +21089,10 @@ ALIAS(no_ip_extcommunity_list_standard_all,
       "Community list name\n")
 
 DEFUN (no_extcommunity_list_expanded_all,
-       no_bgp_extcommunity_list_expanded_all_cmd,
-       "no bgp extcommunity-list <(100-500)|expanded EXTCOMMUNITY_LIST_NAME> [seq (0-4294967295)] <deny|permit> LINE...",
+       no_ip_extcommunity_list_expanded_all_cmd,
+       "no ip extcommunity-list <(100-500)|expanded EXTCOMMUNITY_LIST_NAME> [seq (0-4294967295)] <deny|permit> LINE...",
        NO_STR
-       BGP_STR
+       "ip extcommunity-list (Command for backward compatibility with FRR 6.0.3)\n"
        EXTCOMMUNITY_LIST_STR
        "Extended Community list number (expanded)\n"
        "Specify expanded extcommunity-list\n"
@@ -21367,9 +21146,9 @@ DEFUN (no_extcommunity_list_expanded_all,
 }
 
 ALIAS(no_extcommunity_list_expanded_all,
-      no_bgp_extcommunity_list_expanded_all_list_cmd,
-      "no bgp extcommunity-list <(100-500)|expanded EXTCOMMUNITY_LIST_NAME>",
-      NO_STR BGP_STR EXTCOMMUNITY_LIST_STR
+      no_ip_extcommunity_list_expanded_all_list_cmd,
+      "no ip extcommunity-list <(100-500)|expanded EXTCOMMUNITY_LIST_NAME>",
+      NO_STR "ip extcommunity-list (Command for backward compatibility with FRR 6.0.3)\n" EXTCOMMUNITY_LIST_STR
       "Extended Community list number (expanded)\n"
       "Specify expanded extcommunity-list\n"
       "Extended Community list name\n")
@@ -21405,10 +21184,10 @@ static void extcommunity_list_show(struct vty *vty, struct community_list *list)
 }
 
 DEFUN (show_extcommunity_list,
-       show_bgp_extcommunity_list_cmd,
-       "show bgp extcommunity-list",
+       show_ip_extcommunity_list_cmd,
+       "show ip extcommunity-list",
        SHOW_STR
-       BGP_STR
+       "ip extcommunity-list (Command for backward compatibility with FRR 6.0.3)\n"
        "List extended-community list\n")
 {
 	struct community_list *list;
@@ -21428,10 +21207,10 @@ DEFUN (show_extcommunity_list,
 }
 
 DEFUN (show_extcommunity_list_arg,
-       show_bgp_extcommunity_list_arg_cmd,
-       "show bgp extcommunity-list <(1-500)|EXTCOMMUNITY_LIST_NAME> detail",
+       show_ip_extcommunity_list_arg_cmd,
+       "show ip extcommunity-list <(1-500)|EXTCOMMUNITY_LIST_NAME> detail",
        SHOW_STR
-       BGP_STR
+       "ip extcommunity-list (Command for backward compatibility with FRR 6.0.3)\n"
        "List extended-community list\n"
        "Extcommunity-list number\n"
        "Extcommunity-list name\n"
@@ -21466,7 +21245,7 @@ static int community_list_config_write(struct vty *vty)
 	for (list = cm->num.head; list; list = list->next)
 		for (entry = list->head; entry; entry = entry->next) {
 			vty_out(vty,
-				"bgp community-list %s seq %" PRId64 " %s %s\n",
+				"ip community-list %s seq %" PRId64 " %s %s\n",
 				list->name, entry->seq,
 				community_direct_str(entry->direct),
 				community_list_config_str(entry));
@@ -21475,7 +21254,7 @@ static int community_list_config_write(struct vty *vty)
 	for (list = cm->str.head; list; list = list->next)
 		for (entry = list->head; entry; entry = entry->next) {
 			vty_out(vty,
-				"bgp community-list %s %s seq %" PRId64 " %s %s\n",
+				"ip community-list %s %s seq %" PRId64 " %s %s\n",
 				entry->style == COMMUNITY_LIST_STANDARD
 					? "standard"
 					: "expanded",
@@ -21491,7 +21270,7 @@ static int community_list_config_write(struct vty *vty)
 	for (list = cm->num.head; list; list = list->next)
 		for (entry = list->head; entry; entry = entry->next) {
 			vty_out(vty,
-				"bgp extcommunity-list %s seq %" PRId64 " %s %s\n",
+				"ip extcommunity-list %s seq %" PRId64 " %s %s\n",
 				list->name, entry->seq,
 				community_direct_str(entry->direct),
 				community_list_config_str(entry));
@@ -21500,7 +21279,7 @@ static int community_list_config_write(struct vty *vty)
 	for (list = cm->str.head; list; list = list->next)
 		for (entry = list->head; entry; entry = entry->next) {
 			vty_out(vty,
-				"bgp extcommunity-list %s %s seq %" PRId64" %s %s\n",
+				"ip extcommunity-list %s %s seq %" PRId64" %s %s\n",
 				entry->style == EXTCOMMUNITY_LIST_STANDARD
 					? "standard"
 					: "expanded",
@@ -21552,37 +21331,27 @@ static void community_list_vty(void)
 {
 	install_node(&community_list_node);
 
-	/* Community-list.  */
-	install_element(CONFIG_NODE, &bgp_community_list_standard_cmd);
-	install_element(CONFIG_NODE, &bgp_community_list_expanded_all_cmd);
-	install_element(CONFIG_NODE, &no_bgp_community_list_standard_all_cmd);
-	install_element(CONFIG_NODE, &no_bgp_community_list_standard_all_list_cmd);
-	install_element(CONFIG_NODE, &no_bgp_community_list_expanded_all_cmd);
-	install_element(CONFIG_NODE, &no_bgp_community_list_expanded_all_list_cmd);
-	install_element(VIEW_NODE, &show_bgp_community_list_cmd);
-	install_element(VIEW_NODE, &show_bgp_community_list_arg_cmd);
-
-	/* community list Commands for Backward compatibility with FRR 6.0.3 */
+	 /* community list Commands for Backward compatibility with FRR 6.0.3 */
 	install_element(CONFIG_NODE, &ip_community_list_standard_cmd);
+	install_element(CONFIG_NODE, &ip_community_list_expanded_all_cmd);
 	install_element(CONFIG_NODE, &no_ip_community_list_standard_all_cmd);
 	install_element(CONFIG_NODE, &no_ip_community_list_standard_all_list_cmd);
+	install_element(CONFIG_NODE, &no_ip_community_list_expanded_all_cmd);
+	install_element(CONFIG_NODE, &no_ip_community_list_expanded_all_list_cmd);
+	install_element(VIEW_NODE, &show_ip_community_list_cmd);
+	install_element(VIEW_NODE, &show_ip_community_list_arg_cmd);
 
-	/* Extcommunity-list.  */
-	install_element(CONFIG_NODE, &bgp_extcommunity_list_standard_cmd);
-	install_element(CONFIG_NODE, &bgp_extcommunity_list_name_expanded_cmd);
-	install_element(CONFIG_NODE, &no_bgp_extcommunity_list_standard_all_cmd);
-	install_element(CONFIG_NODE,
-			&no_bgp_extcommunity_list_standard_all_list_cmd);
-	install_element(CONFIG_NODE, &no_bgp_extcommunity_list_expanded_all_cmd);
-	install_element(CONFIG_NODE,
-			&no_bgp_extcommunity_list_expanded_all_list_cmd);
-	install_element(VIEW_NODE, &show_bgp_extcommunity_list_cmd);
-	install_element(VIEW_NODE, &show_bgp_extcommunity_list_arg_cmd);
-
-	/* ext-community list Commands for Backward compatibility with FRR 6.0.3 */
+	/* Extcommunity-list.  Commands for Backward compatibility with FRR 6.0.3 */
 	install_element(CONFIG_NODE, &ip_extcommunity_list_standard_cmd);
+	install_element(CONFIG_NODE, &ip_extcommunity_list_name_expanded_cmd);
 	install_element(CONFIG_NODE, &no_ip_extcommunity_list_standard_all_cmd);
-	install_element(CONFIG_NODE, &no_ip_extcommunity_list_standard_all_list_cmd);
+	install_element(CONFIG_NODE,
+			&no_ip_extcommunity_list_standard_all_list_cmd);
+	install_element(CONFIG_NODE, &no_ip_extcommunity_list_expanded_all_cmd);
+	install_element(CONFIG_NODE,
+			&no_ip_extcommunity_list_expanded_all_list_cmd);
+	install_element(VIEW_NODE, &show_ip_extcommunity_list_cmd);
+	install_element(VIEW_NODE, &show_ip_extcommunity_list_arg_cmd);
 
 	/* Large Community List */
 	install_element(CONFIG_NODE, &bgp_lcommunity_list_standard_cmd);


### PR DESCRIPTION
Testing was done to check whether infiot FRR 8.5.5 accepts community-list commands in 6.0.3 format