### PR TITLE
BWAN-14861: user timeout in running config written in ms instead of sec

### DIFF
--- a/bgpd/bgp_fsm.c
+++ b/bgpd/bgp_fsm.c
@@ -1304,11 +1304,12 @@ static int bgp_connect_success(struct peer *peer)
 	}
 
 	int val = atomic_load(&peer->tcpusrto);
+        int val_ms = val * 1000;
 
         if (CHECK_FLAG(peer->flags, PEER_FLAG_TCP_USER_TIMEOUT) &&
             atomic_load(&peer->tcpusrto) > 0) {
                 if (setsockopt(peer->fd, IPPROTO_TCP, TCP_USER_TIMEOUT,
-                               &val, sizeof(val)) < 0) {
+                               &val_ms, sizeof(val_ms)) < 0) {
                         zlog_warn("Failed to set TCP_USER_TIMEOUT for peer %s: %s",
                                   peer->host, safe_strerror(errno));
                 } else {

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -5099,7 +5099,6 @@ static int peer_tcp_user_timeout_set_vty(struct vty *vty, const char *ip_str,
 {
     struct peer *peer;
     uint32_t timeout_sec;
-    uint32_t timeout_ms;
     int ret;
 
     peer = peer_and_group_lookup_vty(vty, ip_str);
@@ -5113,10 +5112,7 @@ static int peer_tcp_user_timeout_set_vty(struct vty *vty, const char *ip_str,
         return CMD_WARNING_CONFIG_FAILED;
     }
 
-    timeout_ms = timeout_sec * 1000;
-
-
-    ret = peer_tcp_user_timeout_set(peer, timeout_ms);
+    ret = peer_tcp_user_timeout_set(peer, timeout_sec);
     return bgp_vty_return(vty, ret);
 }
 

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -4828,16 +4828,16 @@ int peer_timers_unset(struct peer *peer)
 	return 0;
 }
 
-int peer_tcp_user_timeout_set(struct peer *peer, uint32_t timeout_ms)
+int peer_tcp_user_timeout_set(struct peer *peer, uint32_t timeout_sec)
 {
     struct peer *member;
     struct listnode *node, *nnode;
 
-    if (timeout_ms > (65535 * 1000))
+    if (timeout_sec > 65535)
         return BGP_ERR_INVALID_VALUE;
 
     SET_FLAG(peer->flags, PEER_FLAG_TCP_USER_TIMEOUT);
-    atomic_store(&peer->tcpusrto, timeout_ms);
+    atomic_store(&peer->tcpusrto, timeout_sec);
 
     if (!CHECK_FLAG(peer->sflags, PEER_STATUS_GROUP))
         return 0;


### PR DESCRIPTION
user timeout in running config written in ms instead of sec causing running config validation failure