### PR TITLE
BWAN-15286: Resetting peer when tcp-user-timeout configured

### DIFF
--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -3678,6 +3678,7 @@ static const struct peer_flag_action peer_flag_action_list[] = {
 	{PEER_FLAG_LOCAL_AS_NO_PREPEND, 0, peer_change_none},
 	{PEER_FLAG_LOCAL_AS_REPLACE_AS, 0, peer_change_none},
 	{PEER_FLAG_UPDATE_SOURCE, 0, peer_change_none},
+	{PEER_FLAG_TCP_USER_TIMEOUT, 0, peer_change_reset},
 	{0, 0, 0}};
 
 static const struct peer_flag_action peer_af_flag_action_list[] = {


### PR DESCRIPTION
Resetting peer when tcp-user-timeout configured to renegotiate the timers