### PR TITLE
BWAN-15286: Resetting peer when tcp-user-timeout configured

### DIFF
--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -4437,6 +4437,7 @@ static const struct peer_flag_action peer_flag_action_list[] = {
 	{PEER_FLAG_PORT, 0, peer_change_reset},
 	{PEER_FLAG_AIGP, 0, peer_change_none},
 	{PEER_FLAG_GRACEFUL_SHUTDOWN, 0, peer_change_none},
+	{PEER_FLAG_TCP_USER_TIMEOUT, 0, peer_change_reset},
 	{0, 0, 0}};
 
 static const struct peer_flag_action peer_af_flag_action_list[] = {


### PR DESCRIPTION
Resetting peer when tcp-user-timeout configured to renegotiate the timers

(cherry picked from commit e505e4ea5e92821b090c4274edbc95fff9922769)