### PR TITLE
BWAN-15286: resetting bgp for peer timer attribute config as well

### DIFF
--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -3671,7 +3671,7 @@ static const struct peer_flag_action peer_flag_action_list[] = {
 	{PEER_FLAG_ENFORCE_FIRST_AS, 0, peer_change_reset_in},
 	{PEER_FLAG_IFPEER_V6ONLY, 0, peer_change_reset},
 	{PEER_FLAG_ROUTEADV, 0, peer_change_none},
-	{PEER_FLAG_TIMER, 0, peer_change_none},
+	{PEER_FLAG_TIMER, 0, peer_change_reset},
 	{PEER_FLAG_TIMER_CONNECT, 0, peer_change_none},
 	{PEER_FLAG_PASSWORD, 0, peer_change_none},
 	{PEER_FLAG_LOCAL_AS, 0, peer_change_none},


### PR DESCRIPTION
sometimes bgp timer and tcp-user-timeout config are out of sequence so doing bgp peer reset for timer config as well