### PR TITLE
BWAN-16711: more than once static routes are not added over overlay interface

### DIFF
--- a/staticd/static_routes.c
+++ b/staticd/static_routes.c
@@ -267,7 +267,7 @@ struct static_nexthop *static_add_nexthop(struct static_path *pn,
 	struct static_nexthop *nh;
 	struct static_vrf *nh_svrf;
 	struct interface *ifp;
-	struct static_nexthop *cp;
+	struct static_nexthop *cp = NULL;
 
 	route_lock_node(rn);
 
@@ -376,6 +376,9 @@ void static_install_nexthop(struct static_nexthop *nh)
 	case STATIC_IPV4_GATEWAY_IFNAME:
 	case STATIC_IPV6_GATEWAY_IFNAME:
 		static_zebra_nht_register(nh, true);
+		ifp = if_lookup_by_name(nh->ifname, nh->nh_vrf_id);
+		if (ifp && ifp->ifindex != IFINDEX_INTERNAL)
+			static_install_path(pn);
 		break;
 	case STATIC_BLACKHOLE:
 		static_install_path(pn);


### PR DESCRIPTION
RCA: 
1. Missing immediate install trigger for gateway+ifname nexthops.     - For STATIC_IPV4_GATEWAY_IFNAME / STATIC_IPV6_GATEWAY_IFNAME, install flow relied on NHT registration only. f NHT entry is already registered/reused, a fresh per-prefix route-add trigger may not occur for a newly added prefix. Result: first route installs, subsequent route(s) sharing the same nexthop can be skipped.
2.  Unsafe nexthop insertion cursor initialization. - In static_add_nexthop, insertion cursor cp was not guaranteed deterministic before list insertion logic. That can produce undefined insertion behavior under some paths and make multi-nexthop behavior unstable.

FIX:
Install decision is made by interface validity

An issue https://github.com/frrouting/frr/issues/13010 is already reported in frr for which there is no fix yet