### PR TITLE
BWAN-17269: zebra: use resolved nexthop for VRF ifindex fixup

### DIFF
--- a/zebra/zebra_nhg.c
+++ b/zebra/zebra_nhg.c
@@ -2136,7 +2136,7 @@ interface is overlay and the route VRF differs from the nexthop VRF.
 */
 static void zebra_nexthop_fix_vrf_ifindex(vrf_id_t vrf_id, struct nexthop *nexthop)
 {
-    if (vrf_id == nexthop->vrf_id)
+    if (vrf_id == VRF_DEFAULT)
         return;
 
     const char *ifname = ifindex2ifname(nexthop->ifindex, nexthop->vrf_id);
@@ -2149,8 +2149,10 @@ static void zebra_nexthop_fix_vrf_ifindex(vrf_id_t vrf_id, struct nexthop *nexth
 
     ifindex_t tunindex = ifname2ifindex(vrftunname, vrf_id);
     if (tunindex) {
-        zlog_debug("%s: fixing ifindex overlay->%s (vrf %u)",
-                   __func__, vrftunname, vrf_id);
+        zlog_debug("%s: NH fixup gateway=%pI4 type=%d flags=0x%x ifname:'%s'(%d) -> tunnel='%s'(%d) vrf=%u",
+            __func__, &nexthop->gate.ipv4,
+            nexthop->type, nexthop->flags,
+            ifname, nexthop->ifindex, vrftunname, tunindex, vrf_id);
         nexthop->ifindex = tunindex;
     } else {
 		zlog_debug("%s: failed to fix ifindex for overlay (vrf %u)",
@@ -2510,7 +2512,7 @@ static int nexthop_active(struct nexthop *nexthop, struct nhg_hash_entry *nhe,
 				resolved = 1;
 
 				if (resolver)
-					zebra_nexthop_fix_vrf_ifindex(vrf_id, nexthop);
+					zebra_nexthop_fix_vrf_ifindex(vrf_id, resolver);
 				/* If there are backup nexthops, capture
 				 * that info with the resolving nexthop.
 				 */


### PR DESCRIPTION
nexthop_set_resolved() creates a resolver child that contains the actual forwarding information. The parent nexthop may still have ifindex = 0, while the resolver contains the correct outgoing interface index.

Pass the resolver nexthop to zebra_nexthop_fix_vrf_ifindex() instead of the parent nexthop so VRF ifindex resolution uses the correct interface.

Also change the VRF check to return only for VRF_DEFAULT instead of matching nexthop->vrf_id, allowing VRF-specific resolved nexthops to be processed correctly.