### PR TITLE
BWAN-1663: Evaluate overlay NH only on overlay/127.127.127.127 route

### DIFF
--- a/zebra/rib.h
+++ b/zebra/rib.h
@@ -84,6 +84,13 @@ struct rnh {
 #ifdef ZEBRA_INFIOT_CUSTOM_NEXTHOP_CHECK
         int dest_trkr_index;
         int nh_trkr_index;
+        /* Epoch cache: stores the g_overlay_trkr_eval_seq value at which the
+         * last SHM lookup was performed and its result, so that repeated calls
+         * within the same route-change batch are free. This avoids a linear
+         * lookup into trkr_client_get_trkr_by_index in the case of an
+         * unsuccessful lookup. */
+        uint32_t overlay_trkr_seq;
+        uint8_t  overlay_trkr_reachable;
 #endif
 	struct rnh_list_item rnh_list_item;
 };

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -850,15 +850,15 @@ void zebra_rib_evaluate_rn_nexthops(struct route_node *rn, uint32_t seq,
 		 && (prefix_match(&g_infovlay_prefix, &rn->p)
 		     || (rn->p.prefixlen == IPV4_MAX_BITLEN
 			 && rn->p.u.prefix4.s_addr == overlay_special_v4)));
-	if (overlay_relevant && dest) {
+	if (overlay_relevant) {
 		if (IS_ZEBRA_DEBUG_NHT_DETAILED)
 			zlog_debug(
 				"%s: overlay_relevant is set for %pRN", __func__, rn);
 		if (++g_overlay_trkr_eval_seq == 0) {//wrapcase
 			g_overlay_trkr_eval_seq = 1;  // Skip 0, go to 1 instead
 		}
-		struct zebra_vrf *zvrf = rib_dest_vrf(dest);
 		struct rib_table_info *info = srcdest_rnode_table_info(trigger_rn);
+		struct zebra_vrf *zvrf = info ? info->zvrf : NULL;
 		if (zvrf && info) {
 			zebra_rnh_evaluate_overlay_prefixes(zvrf, info->afi, 0, &trigger_rn->p, info->safi);
 		}

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -838,7 +838,33 @@ void zebra_rib_evaluate_rn_nexthops(struct route_node *rn, uint32_t seq,
 {
 	rib_dest_t *dest = rib_dest_from_rnode(rn);
 	struct rnh *rnh;
+#ifdef ZEBRA_INFIOT_CUSTOM_NEXTHOP_CHECK
+	struct route_node *trigger_rn = rn;
+	const uint32_t overlay_special_v4 = htonl(0x7f7f7f7f);
+	/* Determine whether this route change can affect overlay reachability.
+	 * a route within the overlay supernet (169.254.0.0/16) or 127.127.127.127/32
+	 * can change overlay NHT state.
+	 */
+	const bool overlay_relevant =
+		(rn->p.family == AF_INET
+		 && (prefix_match(&g_infovlay_prefix, &rn->p)
+		     || (rn->p.prefixlen == IPV4_MAX_BITLEN
+			 && rn->p.u.prefix4.s_addr == overlay_special_v4)));
+	if (overlay_relevant && dest) {
+		if (IS_ZEBRA_DEBUG_NHT_DETAILED)
+			zlog_debug(
+				"%s: overlay_relevant is set for %pRN", __func__, rn);
+		if (++g_overlay_trkr_eval_seq == 0) {//wrapcase
+			g_overlay_trkr_eval_seq = 1;  // Skip 0, go to 1 instead
+		}
+		struct zebra_vrf *zvrf = rib_dest_vrf(dest);
+		struct rib_table_info *info = srcdest_rnode_table_info(trigger_rn);
+		if (zvrf && info) {
+			zebra_rnh_evaluate_overlay_prefixes(zvrf, info->afi, 0, &trigger_rn->p, info->safi);
+		}
+	}
 
+#endif
 	/*
 	 * We are storing the rnh's associated withb
 	 * the tracked nexthop as a list of the rn's.
@@ -904,6 +930,22 @@ void zebra_rib_evaluate_rn_nexthops(struct route_node *rn, uint32_t seq,
 			}
 
 			rnh->seqno = seq;
+#ifdef ZEBRA_INFIOT_CUSTOM_NEXTHOP_CHECK
+			/* Skip overlay RNH evaluations for non-overlay-relevant
+			 * route changes.  All unreachable overlay RNHs park at
+			 * 0.0.0.0/0's nht list; the while(rn) walk always reaches
+			 * 0.0.0.0/0, so without this guard every route install
+			 * triggers full RNH evaluations. Overlay reachability is
+			 * independent of non-overlay routes so skipping is safe. */
+			if (!overlay_relevant
+			    && p->family == AF_INET
+			    && prefix_match(&g_infovlay_prefix, p)) {
+				if (IS_ZEBRA_DEBUG_NHT) {
+					zlog_debug("skip overlay RNH %pFX non-overlay route change", p);
+				}
+				continue;
+			}
+#endif
 			zebra_evaluate_rnh(zvrf, family2afi(p->family), 0, p,
 					   rnh->safi);
 		}

--- a/zebra/zebra_rnh.c
+++ b/zebra/zebra_rnh.c
@@ -73,6 +73,10 @@ extern struct trkr_client *g_infovlay_trkr;
 int g_inf_nhcntr_read_success = 0;
 extern int g_inf_is_controller;
 extern struct list *g_inf_ctrl_overlay_ips;
+/* Epoch counter: incremented once per overlay/default route-change event in
+ * zebra_rib_evaluate_rn_nexthops(). Per-RNH cache in check_overlay_nexthop()
+ * uses this to skip redundant SHM lookups within the same batch. */
+uint32_t g_overlay_trkr_eval_seq = 1;
 #endif
 
 static bool compare_state(struct route_entry *r1, struct route_entry *r2);
@@ -80,11 +84,6 @@ static void print_rnh(struct route_node *rn, struct vty *vty,
 		      json_object *json);
 static int zebra_client_cleanup_rnh(struct zserv *client);
 
-#ifdef ZEBRA_INFIOT_CUSTOM_NEXTHOP_CHECK
-static void zebra_rnh_evaluate_overlay_prefixes(struct zebra_vrf *zvrf, afi_t afi,
-                                                int force, const struct prefix *skip_p,
-                                                safi_t safi);
-#endif
 
 void zebra_rnh_init(void)
 {
@@ -574,6 +573,18 @@ static int check_overlay_nexthop(struct prefix *pp, uint8_t *isreachable, struct
 		}
 	}
 
+	/* Epoch cache hit: result already computed for this route-change.
+	 * Return immediately without touching SHM. */
+	if (rnh->overlay_trkr_seq == g_overlay_trkr_eval_seq) {
+		*isreachable = rnh->overlay_trkr_reachable;
+		if (IS_ZEBRA_DEBUG_NHT) {
+			inet_ntop(pp->family, &pp->u.prefix, via, PREFIX2STR_BUFFER);
+			zlog_debug("Overlay cache HIT for %s: reachable=%d seq=%u",
+				   via, *isreachable, g_overlay_trkr_eval_seq);
+		}
+		return *isreachable;
+	}
+
 	// It is possible that when zebra starts, click has not created the
 	// SHM in which case the client initialization will fail in infnh_init.
 	// retry here
@@ -618,6 +629,9 @@ static int check_overlay_nexthop(struct prefix *pp, uint8_t *isreachable, struct
 		zlog_debug("Infiot via: %s, cntrname %s val %llu reachable %d nhindex %d destindex %d", via, cntrname,
 			trkr == NULL ? 1 : trkr->val, *isreachable, rnh->nh_trkr_index, rnh->dest_trkr_index);
 	}
+	/* Store SHM result in per-RNH epoch cache for future hits this batch. */
+	rnh->overlay_trkr_seq = g_overlay_trkr_eval_seq;
+	rnh->overlay_trkr_reachable = *isreachable;
 	return *isreachable;
 }
 #endif
@@ -934,7 +948,7 @@ static void zebra_rnh_clear_nhc_flag(struct zebra_vrf *zvrf, afi_t afi,
 }
 
 #ifdef ZEBRA_INFIOT_CUSTOM_NEXTHOP_CHECK
-static void zebra_rnh_evaluate_overlay_prefixes(struct zebra_vrf *zvrf, afi_t afi,
+void zebra_rnh_evaluate_overlay_prefixes(struct zebra_vrf *zvrf, afi_t afi,
 						int force, const struct prefix *skip_p,
 						safi_t safi)
 {
@@ -976,13 +990,6 @@ void zebra_evaluate_rnh(struct zebra_vrf *zvrf, afi_t afi, int force,
 	if (!rnh_table) // unexpected
 		return;
 
-#ifdef ZEBRA_INFIOT_CUSTOM_NEXTHOP_CHECK
-	/* Before normal evaluation paths, force reevaluation of all tracked
-	 * overlay nexthops for this VRF/AFI/SAFI to flush stale state quickly.
-	 * Skip 'p' when provided to avoid duplicate work in the specific path.
-	 */
-	zebra_rnh_evaluate_overlay_prefixes(zvrf, afi, force, p, safi);
-#endif
 	if (p) {
 		/* Evaluating a specific entry, make sure it exists. */
 		nrn = route_node_lookup(rnh_table, p);

--- a/zebra/zebra_rnh.c
+++ b/zebra/zebra_rnh.c
@@ -73,7 +73,7 @@ extern struct trkr_client *g_infovlay_trkr;
 int g_inf_nhcntr_read_success = 0;
 extern int g_inf_is_controller;
 extern struct list *g_inf_ctrl_overlay_ips;
-/* Epoch counter: incremented once per overlay/default route-change event in
+/* Epoch counter: incremented once per overlay/127.127.127.127/32 route-change event in
  * zebra_rib_evaluate_rn_nexthops(). Per-RNH cache in check_overlay_nexthop()
  * uses this to skip redundant SHM lookups within the same batch. */
 uint32_t g_overlay_trkr_eval_seq = 1;

--- a/zebra/zebra_rnh.h
+++ b/zebra/zebra_rnh.h
@@ -48,6 +48,8 @@ extern void zebra_evaluate_rnh(struct zebra_vrf *zvrf, afi_t afi, int force,
 #ifdef ZEBRA_INFIOT_CUSTOM_NEXTHOP_CHECK
 extern void zebra_rnh_evaluate_overlay_prefixes(struct zebra_vrf *zvrf, afi_t afi,
             int force, const struct prefix *skip_p, safi_t safi);
+/* Epoch counter shared with zebra_rib.c for per-RNH SHM result caching. */
+extern uint32_t g_overlay_trkr_eval_seq;
 #endif
 extern void zebra_print_rnh_table(vrf_id_t vrfid, afi_t afi, safi_t safi,
 				  struct vty *vty, const struct prefix *p,
@@ -70,8 +72,6 @@ void show_route_nexthop_helper(struct vty *vty, const struct route_entry *re,
 
 extern struct prefix g_infovlay_prefix;
 extern struct list *g_inf_ctrl_overlay_ips;
-/* Epoch counter shared with zebra_rib.c for per-RNH SHM result caching. */
-extern uint32_t g_overlay_trkr_eval_seq;
 #ifdef __cplusplus
 }
 #endif

--- a/zebra/zebra_rnh.h
+++ b/zebra/zebra_rnh.h
@@ -45,6 +45,10 @@ extern void zebra_deregister_rnh_pseudowire(vrf_id_t, struct zebra_pw *);
 extern void zebra_remove_rnh_client(struct rnh *rnh, struct zserv *client);
 extern void zebra_evaluate_rnh(struct zebra_vrf *zvrf, afi_t afi, int force,
 			       const struct prefix *p, safi_t safi);
+#ifdef ZEBRA_INFIOT_CUSTOM_NEXTHOP_CHECK
+extern void zebra_rnh_evaluate_overlay_prefixes(struct zebra_vrf *zvrf, afi_t afi,
+            int force, const struct prefix *skip_p, safi_t safi);
+#endif
 extern void zebra_print_rnh_table(vrf_id_t vrfid, afi_t afi, safi_t safi,
 				  struct vty *vty, const struct prefix *p,
 				  json_object *json);
@@ -66,6 +70,8 @@ void show_route_nexthop_helper(struct vty *vty, const struct route_entry *re,
 
 extern struct prefix g_infovlay_prefix;
 extern struct list *g_inf_ctrl_overlay_ips;
+/* Epoch counter shared with zebra_rib.c for per-RNH SHM result caching. */
+extern uint32_t g_overlay_trkr_eval_seq;
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
There was a sanity failure with earlier fix https://github.com/infiotinc/frr/pull/77.  New change added as part of this fix is, evaluate overlay nexthop even on 127.127.127.127/32 route add/del. 

Problem:
Unresolved overlay nexthops (in 169.254/16) are anchored under the default-route NHT bucket. As a result, on each route add, FRR walks that default-route NHT list and invokes zebra_rnh_evaluate_entry for each unresolved overlay nexthop. During this processing, overlay reevaluation also performs another full scan over overlay nexthops (zebra_rnh_evaluate_overlay_prefixes), creating nested iteration over the same set. This leads to quadratic behavior, effectively O(n2) work as the number of unresolved overlay nexthops grows.

Another problem observed is. trkr_client_get_trkr_by_index() is caching the result only on successful search. In failure case it is not caching. For subsequent search it is a linear search( there are around 22K trkrs.)

Fix:

Move overlay nexthop reevlaution logic to the caller, which avoids O(n2) complexity.
Do Overlay nexthop reevlaution only on overlay route + 127.127.127.127/32 route add/del.
Added global epoch counter to avoid SHM linear lookup in case of unsuccessful search.


Sanity suite ran on qa local docker setup:

```
Jun 09 14:58:45;INFO;pyats:8;Creating archive file: /home/infiot/.pyats/archive/26-06/automation_job.2026Jun09_14:47:12.251297.zip
+------------------------------------------------------------------------------+
|                                Easypy Report                                 |
+------------------------------------------------------------------------------+
pyATS Instance   : /usr
Python Version   : cpython-3.10.12 (64bit)
CLI Arguments    : /usr/local/bin/pyats run job /home/infiot/infiotqe/dplane/jobs/automation_job.py --testbed-name simple-hub-spoke-docker --test-dirs basic_sanity --
run --pdb
User             : infiot
Host Server      : dpdev
Host OS Version  : Ubuntu 22.04 jammy (x86_64)

Job Information
    Name         : automation_job
    Result       : PASSED
    Start time   : 2026-06-09 14:47:20.557198+00:00
    Stop time    : 2026-06-09 14:58:44.353943+00:00
    Elapsed time : 0:11:24
    Archive      : /home/infiot/.pyats/archive/26-06/automation_job.2026Jun09_14:47:12.251297.zip

Total Tasks    : 4

Overall Stats
    Passed     : 4
    Passx      : 0
    Failed     : 0
    Aborted    : 0
    Blocked    : 0
    Skipped    : 0
    Errored    : 0

    TOTAL      : 4
Success Rate   : 100.00 %

Section Stats
    Passed     : 32
    Passx      : 0
    Failed     : 0
    Aborted    : 0
    Blocked    : 0
    Skipped    : 0
    Errored    : 0

    TOTAL      : 32

Section Success Rate   : 100.00 %

+------------------------------------------------------------------------------+
|                             Task Result Summary                              |
+------------------------------------------------------------------------------+
basic_sanity:bgp_sanity_1: bgp_sanity                                     PASSED
basic_sanity:bgp_sanity_1: bgp_sanity.test_bgp                            PASSED
basic_sanity:reachability_sanity_1: reachability_sanity                   PASSED
basic_sanity:reachability_sanity_1: reachability_sanity.test_reacha...    PASSED
basic_sanity:inbound_nat_1: inbound_nat                                   PASSED
basic_sanity:inbound_nat_1: inbound_nat.test_inbound_firewall             PASSED
basic_sanity:qos_sanity_1: qos_sanity                                     PASSED
basic_sanity:qos_sanity_1: qos_sanity.test_qos                            PASSED

+------------------------------------------------------------------------------+
|                             Task Result Details                              |
+------------------------------------------------------------------------------+
basic_sanity:bgp_sanity_1: bgp_sanity                                     PASSED
`-- test_bgp                                                              PASSED
    |-- setup                                                             PASSED
    |-- test_bgp_neighbors                                                PASSED
    |-- test_static_route_dist                                            PASSED
    |-- test_network_route_dist                                           PASSED
    `-- cleanup                                                           PASSED
basic_sanity:reachability_sanity_1: reachability_sanity                   PASSED
`-- test_reachability                                                     PASSED
    |-- setup                                                             PASSED
    |-- test_proxy_overlays                                               PASSED
    |-- test_internet_icmp                                                PASSED
    |-- test_internet_tcp                                                 PASSED
    |-- test_internet_udp                                                 PASSED
    |-- test_b2b_icmp                                                     PASSED
    |-- test_overlay_frag_icmp                                            PASSED
    |-- test_backhaul_frag_icmp                                           PASSED
    |-- test_nat_frag                                                     PASSED
    |-- test_b2gw_icmp                                                    PASSED
    |-- test_b2b_tcp                                                      PASSED
    |-- test_b2b_udp                                                      PASSED
    |-- test_overlay_failover                                             PASSED
    |-- test_nat_failover                                                 PASSED
    |-- test_hub_down_failover                                            PASSED
    |-- test_ip_fragment_forwarding_cloud                                 PASSED
    |-- test_ip_fragment_forwarding_vpn                                   PASSED
    |-- test[tc_name=test_internet_backhaul_with_fragmentation]           PASSED
    |-- test[tc_name=test_internet_backhaul_without_fragmentation]        PASSED
    |-- test_ipsec_failover                                               PASSED
    `-- cleanup                                                           PASSED
basic_sanity:inbound_nat_1: inbound_nat                                   PASSED
`-- test_inbound_firewall                                                 PASSED
    |-- test_fw_zone                                                      PASSED
    |-- port_forwarding                                                   PASSED
    `-- one_to_one_nat                                                    PASSED
basic_sanity:qos_sanity_1: qos_sanity                                     PASSED
`-- test_qos                                                              PASSED
    |-- test_policy_match_5tuple                                          PASSED
    |-- test_policy_match_dstip                                           PASSED
    `-- cleanup                                                           PASSED
Jun 09 14:58:45;INFO;pyats:8;Done!

```
