### PR TITLE
BWAN-16683 tcp-user-timeout config is added for EBGP neighbors

### DIFF
--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -1352,7 +1352,6 @@ struct peer {
 #define PEER_FLAG_PASSWORD                  (1ULL << 20) /* password */
 #define PEER_FLAG_LOCAL_AS                  (1ULL << 21) /* local-as */
 #define PEER_FLAG_UPDATE_SOURCE             (1ULL << 22) /* update-source */
-#define PEER_FLAG_TCP_USER_TIMEOUT          (1ULL << 23) /* tcp user timeout */
 
 	/* BGP-GR Peer related  flags */
 #define PEER_FLAG_GRACEFUL_RESTART_HELPER   (1ULL << 23) /* Helper */
@@ -1378,6 +1377,7 @@ struct peer {
 #define PEER_FLAG_PORT (1ULL << 33)
 #define PEER_FLAG_AIGP (1ULL << 34)
 #define PEER_FLAG_GRACEFUL_SHUTDOWN (1ULL << 35)
+#define PEER_FLAG_TCP_USER_TIMEOUT   (1ULL << 36) /* tcp user timeout */
 
 	/*
 	 *GR-Disabled mode means unset PEER_FLAG_GRACEFUL_RESTART


### PR DESCRIPTION
bgpd: fix PEER_FLAG_TCP_USER_TIMEOUT bit collision with PEER_FLAG_GRACEFUL_RESTART_HELPER

**Issue**
Whenever an EBGP neighbor was added, tcp-user-timeout 0 appeared automatically in the running config without the user ever configuring it:

```
router bgp 100
 neighbor 192.168.30.12 remote-as 600
```
Running show running-config would show:

```
router bgp 100
 neighbor 192.168.30.12 remote-as 600
 neighbor 192.168.30.12 tcp-user-timeout 0   ← appeared automatically
```

This was never configured by the user. No neighbor X tcp-user-timeout command was run.

**Root Cause**: Flag Bit Collision
In bgpd/bgpd.h two different flags were assigned the same bit (1ULL << 23):
```
/* BWAN-9819 : porting tcp-user-timeout from frr-6.0.3 to frr-8.5.5*/
#define PEER_FLAG_TCP_USER_TIMEOUT        (1ULL << 23)  /* tcp user timeout */

/* Existing FRR flag */
#define PEER_FLAG_GRACEFUL_RESTART_HELPER (1ULL << 23)  /* GR Helper mode */
```
During BGP session establishment, the FSM sets PEER_FLAG_GRACEFUL_RESTART_HELPER on every EBGP peer:

```
/* bgp_fsm.c: */
SET_FLAG(peer->flags, PEER_FLAG_GRACEFUL_RESTART_HELPER);
```

Because both flags share 1ULL << 23, this also set PEER_FLAG_TCP_USER_TIMEOUT unintentionally. Since a freshly created peer has tcpusrto = 0, the config writer saw the flag set and printed:

`neighbor 192.168.30.12 tcp-user-timeout 0`
This happened silently — no VTY command, no peer_tcp_user_timeout_set_vty() call. As a side effect of setting PEER_FLAG_GRACEFUL_RESTART_HELPER flag.

**Fix**
Move PEER_FLAG_TCP_USER_TIMEOUT to an unused bit:

```
/* Before (collides with PEER_FLAG_GRACEFUL_RESTART_HELPER) */
#define PEER_FLAG_TCP_USER_TIMEOUT  (1ULL << 23)

/* After (next free bit after PEER_FLAG_GRACEFUL_SHUTDOWN at bit 35) */
#define PEER_FLAG_TCP_USER_TIMEOUT  (1ULL << 36)
```

**Result After Fix**
```
router bgp 100
 neighbor 192.168.30.12 remote-as 600
```
show running-config now shows:

```
router bgp 100
 neighbor 192.168.30.12 remote-as 600
 ← no spurious tcp-user-timeout 0
```
tcp-user-timeout only appears when explicitly configured with a non-zero value:

`neighbor 192.168.30.12 tcp-user-timeout 300`