### PR TITLE
zebra: gate FPM per-write log behind FPM debug flag

### DIFF
--- a/zebra/zebra_fpm.c
+++ b/zebra/zebra_fpm.c
@@ -1160,7 +1160,7 @@ static int zfpm_write_cb(struct thread *thread)
 			write(zfpm_g->sock, stream_pnt(s), bytes_to_write);
 		zfpm_g->stats.write_calls++;
 		num_writes++;
-		zlog_debug("sent out fd:%d bytes_to_write:%ld bytes_written:%ld",
+		zfpm_debug("sent out fd:%d bytes_to_write:%ld bytes_written:%ld",
 				zfpm_g->sock, bytes_to_write, bytes_written);
 
 		if (bytes_written < 0) {


### PR DESCRIPTION
The FPM write callback logged "sent out fd..." on every socket write using a raw zlog_debug, so it leaked out whenever general debug logging was on and flooded the zebra logs. Every other FPM log uses the zfpm_debug macro, which is gated behind IS_ZEBRA_DEBUG_FPM. Switch this line to zfpm_debug so it stays silent unless FPM debugging is explicitly enabled.

This fixes BWAN-18921 FPM write-callback floods zebra logs on every write